### PR TITLE
Add "Ejectable" element base class

### DIFF
--- a/.idea/dictionaries/project.xml
+++ b/.idea/dictionaries/project.xml
@@ -1,8 +1,0 @@
-<component name="ProjectDictionaryState">
-  <dictionary name="project">
-    <words>
-      <w>autovideosink</w>
-      <w>cameracontrolwindow</w>
-    </words>
-  </dictionary>
-</component>

--- a/keela-pipeline/CMakeLists.txt
+++ b/keela-pipeline/CMakeLists.txt
@@ -26,6 +26,8 @@ add_library(keela-pipeline presentationbin.cpp keela-pipeline/presentationbin.h
         keela-pipeline/snapshotbin.h
         TraceBin.cpp
         keela-pipeline/TraceBin.h
+        EjectableElement.cpp
+        keela-pipeline/EjectableElement.h
 )
 target_link_libraries(keela-pipeline PUBLIC PkgConfig::GSTREAMER PkgConfig::SPDLOG)
 

--- a/keela-pipeline/EjectableElement.cpp
+++ b/keela-pipeline/EjectableElement.cpp
@@ -1,0 +1,96 @@
+//
+// Created by brand on 9/1/2025.
+//
+
+#include "keela-pipeline/EjectableElement.h"
+
+void Keela::EjectableElement::PrepareEject() {
+    // TODO: can this be the sink pad instead?
+    auto head = Head();
+    const auto pad = gst_element_get_static_pad(head, "sink");
+    assert(pad != nullptr);
+
+    auto peer = gst_pad_get_peer(pad);
+    assert(peer != nullptr);
+    //auto peer_parent = gst_pad_get_parent_element(peer);
+    spdlog::debug("peer is {}",GST_ELEMENT_NAME(peer));
+    gst_pad_add_probe(peer,
+                      GST_PAD_PROBE_TYPE_BLOCK_DOWNSTREAM,
+                      pad_block_callback,
+                      this,
+                      nullptr);
+    g_object_unref(pad);
+    g_object_unref(peer);
+}
+
+void Keela::EjectableElement::Eject() {
+    auto lock = std::unique_lock(remove_mutex);
+    remove_condition.wait(lock, [this]() {
+        return this->safe_to_remove;
+    });
+    lock.unlock();
+    auto state_ret = gst_element_set_state(GST_ELEMENT(this), GST_STATE_NULL);
+    auto parent = GST_ELEMENT_PARENT(this);
+    if (parent == nullptr) {
+        throw std::runtime_error("Could not eject element from pipeline. parent is null");
+    }
+    auto remove_ret = gst_bin_remove(GST_BIN(parent), *this); // ?
+    auto name = GST_ELEMENT_NAME(static_cast<GstElement*>(*this));
+    if (state_ret == GST_STATE_CHANGE_FAILURE || !remove_ret) {
+        spdlog::error("could not remove {} from pipeline", name);
+    } else {
+        spdlog::info("successfully removed {} from pipeline", name);
+    }
+}
+
+GstPadProbeReturn Keela::EjectableElement::pad_block_callback(GstPad *pad, GstPadProbeInfo *info, gpointer user_data) {
+    auto bin = static_cast<Keela::EjectableElement *>(user_data);
+    auto name = GST_ELEMENT_NAME(static_cast<GstElement*>(*bin));
+    spdlog::info("Pad block received from {}", name);
+    gst_pad_remove_probe(pad, GST_PAD_PROBE_INFO_ID(info));
+
+    spdlog::debug("setting eos callback");
+    auto tail = bin->Tail();
+    auto tailpad = gst_element_get_static_pad(tail, "src");
+    assert(file_sink_pad != nullptr);
+
+
+    gst_pad_add_probe(tailpad,
+                      static_cast<GstPadProbeType>(GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM),
+                      event_callback,
+                      bin, nullptr);
+    g_object_unref(tailpad);
+
+    spdlog::debug("sending EOS");
+
+    auto head = bin->Head();
+    auto headpad = gst_element_get_static_pad(head, "sink");
+    auto headpad_peer = gst_pad_get_peer(headpad);
+    gst_pad_unlink(headpad_peer, headpad);
+    gst_pad_send_event(headpad, gst_event_new_eos());
+    g_object_unref(headpad);
+    g_object_unref(headpad_peer);
+    bin->dump_bin_graph();
+    return GST_PAD_PROBE_OK;
+}
+
+GstPadProbeReturn Keela::EjectableElement::event_callback(GstPad *pad, GstPadProbeInfo *info, gpointer user_data) {
+    auto bin = static_cast<EjectableElement *>(user_data);
+    if (GST_EVENT_TYPE(GST_PAD_PROBE_INFO_DATA(info)) != GST_EVENT_EOS) {
+        return GST_PAD_PROBE_OK;
+    }
+    auto name = GST_ELEMENT_NAME(static_cast<GstElement*>(*bin));
+    spdlog::info("EOS received from {}", name);
+
+    gst_pad_remove_probe(pad, GST_PAD_PROBE_INFO_ID(info));
+
+    bin->dump_bin_graph();
+    // acquire lock and set signal variable
+    {
+        auto lock = std::scoped_lock(bin->remove_mutex);
+        bin->safe_to_remove = true;
+    }
+    bin->remove_condition.notify_all();
+
+    return GST_PAD_PROBE_OK;
+}

--- a/keela-pipeline/EjectableElement.cpp
+++ b/keela-pipeline/EjectableElement.cpp
@@ -5,9 +5,20 @@
 #include "keela-pipeline/EjectableElement.h"
 
 void Keela::EjectableElement::PrepareEject() {
-    // TODO: can this be the sink pad instead?
+    /*
+     * How this works:
+     *
+     * First, install a blocking pad probe to prevent further processing.
+     * Inside of the pad probe perform the following
+     *      - unlink the pad from its peer to stop further processing of new data
+     *      - install an event probe on the final element of the bin to detect EOS events
+     *      - send an EOS event to the head of the bin
+     * Inside of the EOS probe
+     *      - wait for the EOS event
+     *      - set synchronization variables to signal that the element is safe to remove from the pipeline
+     */
     auto head = Head();
-    const auto pad = gst_element_get_static_pad(head, "sink");
+    const auto pad = gst_element_get_static_pad(*head, "sink");
     assert(pad != nullptr);
 
     auto peer = gst_pad_get_peer(pad);
@@ -31,10 +42,13 @@ void Keela::EjectableElement::Eject() {
     lock.unlock();
 
     auto name = GST_ELEMENT_NAME(static_cast<GstElement*>(*this));
+    spdlog::info("Eject {}", name);
     auto state_ret = gst_element_set_state(GST_ELEMENT(static_cast<GstElement*>(*this)), GST_STATE_NULL);
     auto parent = GST_ELEMENT_PARENT(static_cast<GstElement*>(*this));
     if (GST_IS_BIN(parent)) {
-        throw std::runtime_error("Could not eject element from pipeline. Element has no parent");
+        spdlog::warn("Could not eject element from pipeline. Element has no parent");
+        // not super sure if this is an actual error
+        //throw std::runtime_error("Could not eject element from pipeline. Element has no parent");
     }
     auto remove_ret = gst_bin_remove(GST_BIN(parent), *this);
     if (state_ret == GST_STATE_CHANGE_FAILURE || !remove_ret) {
@@ -51,23 +65,25 @@ GstPadProbeReturn Keela::EjectableElement::pad_block_callback(GstPad *pad, GstPa
     gst_pad_remove_probe(pad, GST_PAD_PROBE_INFO_ID(info));
 
     spdlog::debug("setting eos callback");
-    auto tail = bin->Tail();
-    auto tailpad = gst_element_get_static_pad(tail, "src");
-    assert(tailpad != nullptr);
+    for (auto tail: bin->Leaves()) {
+        auto tailpad = gst_element_get_static_pad(*tail, "src");
+        assert(tailpad != nullptr);
 
 
-    gst_pad_add_probe(tailpad,
-                      static_cast<GstPadProbeType>(GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM),
-                      event_callback,
-                      bin, nullptr);
-    g_object_unref(tailpad);
-
+        gst_pad_add_probe(tailpad,
+                          static_cast<GstPadProbeType>(GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM),
+                          event_callback,
+                          bin, nullptr);
+        g_object_unref(tailpad);
+    }
     spdlog::debug("sending EOS");
 
+    // unlink head from its peer
     auto head = bin->Head();
-    auto headpad = gst_element_get_static_pad(head, "sink");
+    auto headpad = gst_element_get_static_pad(*head, "sink");
     auto headpad_peer = gst_pad_get_peer(headpad);
     gst_pad_unlink(headpad_peer, headpad);
+    // send EOS event to the head but ONLY after first installing the EOS callback - otherwise the EOS may not be caught
     gst_pad_send_event(headpad, gst_event_new_eos());
     g_object_unref(headpad);
     g_object_unref(headpad_peer);

--- a/keela-pipeline/keela-pipeline/EjectableElement.h
+++ b/keela-pipeline/keela-pipeline/EjectableElement.h
@@ -11,6 +11,8 @@
 namespace Keela {
     /**
      * A pipeline element that may be removed from a pipeline during live playback
+     *
+     * This class is only suitable for elements which lie at the end of the pipeline and have no downstream elements.
      */
     class EjectableElement : virtual private Keela::Element {
     public:
@@ -22,8 +24,11 @@ namespace Keela {
 
         /**
          * Eject the element from the pipeline and wait for it to finish processing remaining data.
+         *
+         *
+        * @param prepare true if the element should prepare itself for ejection, false if not
          */
-        void Eject();
+        void Eject(bool prepare);
 
     private:
         /**
@@ -47,6 +52,9 @@ namespace Keela {
         /// callback cleans up any remaining data from the bin and removes it from the pipeline
         static GstPadProbeReturn event_callback(GstPad *pad, GstPadProbeInfo *info, gpointer user_data);
 
+        /// used to count how many EOS events recieved from the leaf elements
+        unsigned int leaves_eos_count = 0;
+        bool is_ejecting = false;
         bool safe_to_remove = false;
         std::mutex remove_mutex;
         std::condition_variable remove_condition;

--- a/keela-pipeline/keela-pipeline/EjectableElement.h
+++ b/keela-pipeline/keela-pipeline/EjectableElement.h
@@ -1,0 +1,56 @@
+//
+// Created by brand on 9/1/2025.
+//
+
+#ifndef EJECTBIN_H
+#define EJECTBIN_H
+#include "bin.h"
+#include "elementbase.h"
+
+
+namespace Keela {
+    /**
+     * A pipeline element that may be removed from a pipeline during live playback
+     */
+    class EjectableElement : public Keela::Bin {
+    public:
+        /**
+         * Prepare the element for ejection from the pipeline, but do not wait for the element to finish processing remaining data.
+         */
+        void PrepareEject();
+
+
+        /**
+         * Eject the element from the pipeline and wait for it to finish processing remaining data.
+         */
+        void Eject();
+
+    private:
+        /**
+         * Get a pointer to the first element in the bin. Subclasses must be able to guarantee that they own the element pointer
+         *
+         * @return
+         */
+        virtual GstElement *Head() = 0;
+
+
+        /**
+         * get a pointer to the last element in the bin. Subclass must be able to guarantee that they own the element pointer
+         * @return
+         */
+        virtual GstElement *Tail() = 0;
+
+        /// callback unlinks element, sends EOS on its src, then installs an EOS event callback to clean up the remaining data
+        static GstPadProbeReturn pad_block_callback(GstPad *pad, GstPadProbeInfo *info, gpointer user_data);
+
+        /// callback cleans up any remaining data from the bin and removes it from the pipeline
+        static GstPadProbeReturn event_callback(GstPad *pad, GstPadProbeInfo *info, gpointer user_data);
+
+        bool safe_to_remove = false;
+        std::mutex remove_mutex;
+        std::condition_variable remove_condition;
+    };
+}
+
+
+#endif //EJECTBIN_H

--- a/keela-pipeline/keela-pipeline/EjectableElement.h
+++ b/keela-pipeline/keela-pipeline/EjectableElement.h
@@ -12,7 +12,7 @@ namespace Keela {
     /**
      * A pipeline element that may be removed from a pipeline during live playback
      */
-    class EjectableElement {
+    class EjectableElement : virtual private Keela::Element {
     public:
         /**
          * Prepare the element for ejection from the pipeline, but do not wait for the element to finish processing remaining data.
@@ -43,7 +43,7 @@ namespace Keela {
         /**
          * Hacky way to avoid ambiguity of conversion of this to GstElement* since we're using multiple inheritance
          */
-        virtual GstElement *Element() = 0;
+        //virtual GstElement *Element() = 0;
 
         /// callback unlinks element, sends EOS on its src, then installs an EOS event callback to clean up the remaining data
         static GstPadProbeReturn pad_block_callback(GstPad *pad, GstPadProbeInfo *info, gpointer user_data);

--- a/keela-pipeline/keela-pipeline/EjectableElement.h
+++ b/keela-pipeline/keela-pipeline/EjectableElement.h
@@ -31,19 +31,15 @@ namespace Keela {
          *
          * @return
          */
-        virtual GstElement *Head() = 0;
+        virtual Keela::Element *Head() = 0;
 
 
         /**
-         * get a pointer to the last element in the bin. Subclass must be able to guarantee that they own the element pointer
-         * @return
+         * get a list of the "leaf" elements of the bin. Subclasses must be able to guarantee that they own all element pointers
+         *
+         * @return a list of all "leaf" elements in the bin
          */
-        virtual GstElement *Tail() = 0;
-
-        /**
-         * Hacky way to avoid ambiguity of conversion of this to GstElement* since we're using multiple inheritance
-         */
-        //virtual GstElement *Element() = 0;
+        virtual std::vector<Keela::Element *> Leaves() = 0;
 
         /// callback unlinks element, sends EOS on its src, then installs an EOS event callback to clean up the remaining data
         static GstPadProbeReturn pad_block_callback(GstPad *pad, GstPadProbeInfo *info, gpointer user_data);

--- a/keela-pipeline/keela-pipeline/EjectableElement.h
+++ b/keela-pipeline/keela-pipeline/EjectableElement.h
@@ -12,7 +12,7 @@ namespace Keela {
     /**
      * A pipeline element that may be removed from a pipeline during live playback
      */
-    class EjectableElement : public Keela::Bin {
+    class EjectableElement {
     public:
         /**
          * Prepare the element for ejection from the pipeline, but do not wait for the element to finish processing remaining data.
@@ -39,6 +39,11 @@ namespace Keela {
          * @return
          */
         virtual GstElement *Tail() = 0;
+
+        /**
+         * Hacky way to avoid ambiguity of conversion of this to GstElement* since we're using multiple inheritance
+         */
+        virtual GstElement *Element() = 0;
 
         /// callback unlinks element, sends EOS on its src, then installs an EOS event callback to clean up the remaining data
         static GstPadProbeReturn pad_block_callback(GstPad *pad, GstPadProbeInfo *info, gpointer user_data);

--- a/keela-pipeline/keela-pipeline/bin.h
+++ b/keela-pipeline/keela-pipeline/bin.h
@@ -13,7 +13,7 @@
 #include "elementbase.h"
 
 namespace Keela {
-    class Bin : public Keela::Element {
+    class Bin : public virtual Keela::Element {
     public:
         explicit Bin(const std::string &name);
 

--- a/keela-pipeline/keela-pipeline/queuebin.h
+++ b/keela-pipeline/keela-pipeline/queuebin.h
@@ -6,6 +6,7 @@
 #define QUEUEBIN_H
 #include <keela-pipeline/bin.h>
 
+#include "EjectableElement.h"
 #include "simpleelement.h"
 
 namespace Keela {

--- a/keela-pipeline/keela-pipeline/recordbin.h
+++ b/keela-pipeline/keela-pipeline/recordbin.h
@@ -44,9 +44,10 @@ namespace Keela {
             return mux;
         }
 
+        /*
         GstElement *Element() override {
             return *this;
-        };;
+        };;*/
 
         std::string name;
     };

--- a/keela-pipeline/keela-pipeline/recordbin.h
+++ b/keela-pipeline/keela-pipeline/recordbin.h
@@ -9,7 +9,7 @@
 #include "simpleelement.h"
 
 namespace Keela {
-    class RecordBin final : public QueueBin {
+    class RecordBin final : public QueueBin, public EjectableElement {
     public:
         explicit RecordBin(const std::string &name);
 
@@ -35,6 +35,18 @@ namespace Keela {
         void link() override;
 
         void init() override;
+
+        GstElement *Head() override {
+            return queue;
+        };
+
+        GstElement *Tail() override {
+            return mux;
+        }
+
+        GstElement *Element() override {
+            return *this;
+        };;
 
         std::string name;
     };

--- a/keela-pipeline/keela-pipeline/recordbin.h
+++ b/keela-pipeline/keela-pipeline/recordbin.h
@@ -36,12 +36,14 @@ namespace Keela {
 
         void init() override;
 
-        GstElement *Head() override {
-            return queue;
+        Keela::Element *Head() override {
+            return &queue;
         };
 
-        GstElement *Tail() override {
-            return mux;
+        std::vector<Keela::Element *> Leaves() override {
+            std::vector<Keela::Element *> ret;
+            ret.push_back(&mux);
+            return ret;
         }
 
         /*

--- a/keela-pipeline/keela-pipeline/simpleelement.h
+++ b/keela-pipeline/keela-pipeline/simpleelement.h
@@ -10,7 +10,7 @@
 #include "elementbase.h"
 
 namespace Keela {
-    class SimpleElement : public Keela::Element {
+    class SimpleElement : public virtual Keela::Element {
     public:
         explicit SimpleElement(const std::string &element);
 

--- a/keela-widgets/cameramanager.cpp
+++ b/keela-widgets/cameramanager.cpp
@@ -89,7 +89,7 @@ void Keela::CameraManager::stop_recording() {
     }
 
     for (auto bin: record_bins) {
-        bin->Eject();
+        bin->Eject(false);
     }
     record_bins.clear();
     spdlog::info("Removed all recordbins from pipeline");

--- a/keela-widgets/cameramanager.cpp
+++ b/keela-widgets/cameramanager.cpp
@@ -85,100 +85,13 @@ void Keela::CameraManager::stop_recording() {
     // after installing the EOS callback, send an EOS event to the sink pad of the beginning of the bin
     // inside the EOS callback, set the state of the bin to NULL and remove the bin from the pipeline
     for (auto bin: record_bins) {
-        /*
-        auto copy = new std::shared_ptr(bin);
-        // TODO: can this be the sink pad instead?
-        const auto pad = gst_element_get_static_pad(bin->queue, "sink");
-        assert(pad != nullptr);
-
-        auto peer = gst_pad_get_peer(pad);
-        assert(peer != nullptr);
-        //auto peer_parent = gst_pad_get_parent_element(peer);
-        spdlog::debug("peer is {}",GST_ELEMENT_NAME(peer));
-        gst_pad_add_probe(peer,
-                          GST_PAD_PROBE_TYPE_BLOCK_DOWNSTREAM,
-                          pad_block_callback,
-                          copy,
-                          nullptr);
-        g_object_unref(pad);
-        g_object_unref(peer);*/
         bin->PrepareEject();
     }
 
     for (auto bin: record_bins) {
-        /*
-        auto lock = std::unique_lock(bin->remove_mutex);
-        bin->remove_condition.wait(lock, [bin]() {
-            return bin->safe_to_remove;
-        });
-        lock.unlock();
-        auto state_ret = gst_element_set_state(*bin, GST_STATE_NULL);
-        auto remove_ret = gst_bin_remove(*this, *bin);
-        auto name = GST_ELEMENT_NAME(static_cast<GstElement*>(*this));
-        if (state_ret == GST_STATE_CHANGE_FAILURE || !remove_ret) {
-            spdlog::error("{} could not remove recordbin from pipeline", name);
-        } else {
-            spdlog::info("{} successfully removed recordbin from pipeline", name);
-        }*/
         bin->Eject();
     }
     record_bins.clear();
     spdlog::info("Removed all recordbins from pipeline");
     dump_bin_graph();
-}
-
-GstPadProbeReturn Keela::CameraManager::pad_block_callback(GstPad *pad, GstPadProbeInfo *info, gpointer user_data) {
-    auto recordbin = static_cast<std::shared_ptr<RecordBin> *>(user_data);
-    auto name = GST_ELEMENT_NAME(static_cast<GstElement*>(**recordbin));
-    spdlog::info("Pad block received from {}", name);
-    gst_pad_remove_probe(pad, GST_PAD_PROBE_INFO_ID(info));
-
-    spdlog::debug("setting eos callback");
-    auto file_sink_pad = gst_element_get_static_pad((*recordbin)->mux, "src");
-    assert(file_sink_pad != nullptr);
-
-
-    gst_pad_add_probe(file_sink_pad,
-                      static_cast<GstPadProbeType>(GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM),
-                      event_callback,
-                      recordbin, nullptr);
-    g_object_unref(file_sink_pad);
-
-    spdlog::debug("sending EOS");
-
-    auto queuepad = gst_element_get_static_pad((*recordbin)->queue, "sink");
-    auto queue_peer = gst_pad_get_peer(queuepad);
-    gst_pad_unlink(queue_peer, queuepad);
-    gst_pad_send_event(queuepad, gst_event_new_eos());
-    g_object_unref(queuepad);
-    g_object_unref(queue_peer);
-    (*recordbin)->dump_bin_graph();
-    return GST_PAD_PROBE_OK;
-}
-
-GstPadProbeReturn Keela::CameraManager::event_callback(GstPad *pad, GstPadProbeInfo *info, gpointer user_data) {
-    auto recordbin = static_cast<std::shared_ptr<RecordBin> *>(user_data);
-    if (GST_EVENT_TYPE(GST_PAD_PROBE_INFO_DATA(info)) != GST_EVENT_EOS) {
-        return GST_PAD_PROBE_OK;
-    }
-    auto name = GST_ELEMENT_NAME(static_cast<GstElement*>(**recordbin));
-    spdlog::info("EOS received from {}", name);
-
-    gst_pad_remove_probe(pad, GST_PAD_PROBE_INFO_ID(info));
-
-    (*recordbin)->dump_bin_graph();
-    // acquire lock and set signal variable
-    {
-        auto lock = std::scoped_lock((*recordbin)->remove_mutex);
-        (*recordbin)->safe_to_remove = true;
-    }
-    (*recordbin)->remove_condition.notify_all();
-
-    //gst_element_set_state(**recordbin, GST_STATE_NULL);
-    // auto parent = GST_ELEMENT_PARENT(static_cast<GstElement*>(**recordbin));
-    // because recordbin is supposed to be inside a pipeline, it should have a parent
-    //assert(parent != nullptr);
-    //gst_bin_remove(GST_BIN(parent), **recordbin);
-    delete recordbin;
-    return GST_PAD_PROBE_OK;
 }

--- a/keela-widgets/cameramanager.cpp
+++ b/keela-widgets/cameramanager.cpp
@@ -85,6 +85,7 @@ void Keela::CameraManager::stop_recording() {
     // after installing the EOS callback, send an EOS event to the sink pad of the beginning of the bin
     // inside the EOS callback, set the state of the bin to NULL and remove the bin from the pipeline
     for (auto bin: record_bins) {
+        /*
         auto copy = new std::shared_ptr(bin);
         // TODO: can this be the sink pad instead?
         const auto pad = gst_element_get_static_pad(bin->queue, "sink");
@@ -100,10 +101,12 @@ void Keela::CameraManager::stop_recording() {
                           copy,
                           nullptr);
         g_object_unref(pad);
-        g_object_unref(peer);
+        g_object_unref(peer);*/
+        bin->PrepareEject();
     }
 
     for (auto bin: record_bins) {
+        /*
         auto lock = std::unique_lock(bin->remove_mutex);
         bin->remove_condition.wait(lock, [bin]() {
             return bin->safe_to_remove;
@@ -116,7 +119,8 @@ void Keela::CameraManager::stop_recording() {
             spdlog::error("{} could not remove recordbin from pipeline", name);
         } else {
             spdlog::info("{} successfully removed recordbin from pipeline", name);
-        }
+        }*/
+        bin->Eject();
     }
     record_bins.clear();
     spdlog::info("Removed all recordbins from pipeline");

--- a/keela-widgets/keela-widgets/cameramanager.h
+++ b/keela-widgets/keela-widgets/cameramanager.h
@@ -66,14 +66,12 @@ namespace Keela {
          */
         SimpleElement auto_video_convert = SimpleElement("videoconvert");
 
-        /// at any moment there may be many active record bins
+        /* at any moment there may be many active record bins
+         *
+         * TODO: do these still need to be shared_ptr?
+         *
+         */
         std::set<std::shared_ptr<RecordBin> > record_bins;
-
-        /// callback unlinks recordbin, sends EOS on its src, then installs an EOS event callback to clean up the remaining data
-        static GstPadProbeReturn pad_block_callback(GstPad *pad, GstPadProbeInfo *info, gpointer user_data);
-
-        /// callback cleans up any remaining data from the recordbin and removes it from the pipeline
-        static GstPadProbeReturn event_callback(GstPad *pad, GstPadProbeInfo *info, gpointer user_data);
     };
 }
 #endif //CAMERAMANAGER_H


### PR DESCRIPTION
This PR creates a class `EjectableElement` which gives an element the capability to be removed from a playing pipeline without interrupting playback.

Subclasses are responsible for providing references to their "head" and "leaf" elements

Upon Ejection an EOS event is sent to the head element and the EjectableElement is not considered safe to remove from the pipeline until the EOS event is seen by all "leaf" elements