### PR TITLE
Prepend recording filename with current time

### DIFF
--- a/keela-exe/mainwindow.cpp
+++ b/keela-exe/mainwindow.cpp
@@ -153,8 +153,7 @@ void MainWindow::on_record_button_clicked() {
         if (experiment_directory == "") {
             throw std::runtime_error("Experiment directory not specified");
         }
-        auto message_dialog = Gtk::MessageDialog("Remember to set the experiment output to a new directory");
-        message_dialog.run();
+
         // TODO: show file dialog
         for (const auto &camera: cameras) {
             camera->camera_manager->start_recording();

--- a/keela-widgets/keela-widgets/cameramanager.h
+++ b/keela-widgets/keela-widgets/cameramanager.h
@@ -72,6 +72,13 @@ namespace Keela {
          *
          */
         std::set<std::shared_ptr<RecordBin> > record_bins;
+
+        /*
+         * prepends the filename with the current time to avoid overwriting files
+         * ex: directory/20250915_181211_cam_1.mkv
+         * supports cross-platform path joining
+         */
+        static std::string get_filename(std::string directory, guint cam_id);
     };
 }
 #endif //CAMERAMANAGER_H


### PR DESCRIPTION
* prepends the recording filename with the current time to prevent accidentally overwriting experimental data
* switches to using the filesystem::path api to support cross platform path joining

`cam_1.mkv` -> `20250915_181211_cam_1.mkv`