### PR TITLE
Split frame traces

### DIFF
--- a/keela-exe/cameracontrolwindow.cpp
+++ b/keela-exe/cameracontrolwindow.cpp
@@ -205,6 +205,21 @@ void Keela::CameraControlWindow::update_traces() {
         );
         m_traces.push_back(odd_trace);
     }
+    
+    // Notify parent that traces have been updated
+    if (on_traces_updated_callback) {
+        on_traces_updated_callback();
+    }
+}
+
+void Keela::CameraControlWindow::apply_trace_framerate(guint fps) {
+    spdlog::info("Applying trace framerate {} to all traces for camera {}", fps, id);
+    for (const auto &trace : m_traces) {
+        auto trace_bin = trace->get_trace_bin();
+        if (trace_bin) {
+            trace_bin->set_trace_framerate(fps);
+        }
+    }
 }
 
 void Keela::CameraControlWindow::add_split_frame_ui() {

--- a/keela-exe/cameracontrolwindow.cpp
+++ b/keela-exe/cameracontrolwindow.cpp
@@ -7,11 +7,10 @@
 #include <keela-widgets/framebox.h>
 #include <spdlog/spdlog.h>
 
-Keela::CameraControlWindow::CameraControlWindow(const guint id, std::string pix_fmt) {
+Keela::CameraControlWindow::CameraControlWindow(const guint id, std::string pix_fmt, bool should_split_frames) {
     this->id = id;
     spdlog::info("Creating {} for camera {}", __func__, id);
-    bool split_frames = false;
-    camera_manager = std::make_unique<Keela::CameraManager>(id, pix_fmt, split_frames);
+    camera_manager = std::make_unique<Keela::CameraManager>(id, pix_fmt, should_split_frames);
 
     set_title("Image control for Camera " + std::to_string(id));
     set_resizable(false);
@@ -51,11 +50,6 @@ Keela::CameraControlWindow::CameraControlWindow(const guint id, std::string pix_
     v_container.add(flip_horiz_check);
     flip_vert_check.signal_toggled().connect(sigc::mem_fun(*this, &CameraControlWindow::on_flip_vert_changed));
     v_container.add(flip_vert_check);
-
-    // Add frame splitting control
-    split_frames_check.signal_toggled().connect(sigc::mem_fun(*this, &CameraControlWindow::on_split_frames_changed));
-    split_frames_check.set_active(camera_manager->is_frame_splitting_enabled());
-    v_container.add(split_frames_check);
 
     // TODO: dynamically cast camera_manager->presentation to a WidgetElement to get a handle to a widget to add to the window
     fetch_image_button.signal_clicked().connect(
@@ -157,10 +151,9 @@ void Keela::CameraControlWindow::on_flip_vert_changed() const {
     camera_manager->transform.flip_vertical(value);
 }
 
-void Keela::CameraControlWindow::on_split_frames_changed() {
-    const auto value = split_frames_check.get_active();
-    camera_manager->set_frame_splitting(value);
-    if (value) {
+void Keela::CameraControlWindow::on_split_frames_changed(bool should_split_frames) {
+    camera_manager->set_frame_splitting(should_split_frames);
+    if (should_split_frames) {
         spdlog::info("Adding split frame UI");
         add_split_frame_ui();
     } else {

--- a/keela-exe/cameracontrolwindow.cpp
+++ b/keela-exe/cameracontrolwindow.cpp
@@ -151,7 +151,7 @@ void Keela::CameraControlWindow::on_flip_vert_changed() const {
     camera_manager->transform.flip_vertical(value);
 }
 
-void Keela::CameraControlWindow::on_split_frames_changed(bool should_split_frames) {
+void Keela::CameraControlWindow::update_split_frame_state(bool should_split_frames) {
     camera_manager->set_frame_splitting(should_split_frames);
     if (should_split_frames) {
         spdlog::info("Adding split frame UI");
@@ -197,11 +197,6 @@ void Keela::CameraControlWindow::update_traces() {
             "Camera " + std::to_string(id) + " (Odd)"
         );
         m_traces.push_back(odd_trace);
-    }
-    
-    // Notify parent that traces have been updated
-    if (on_traces_updated_callback) {
-        on_traces_updated_callback();
     }
 }
 

--- a/keela-exe/cameracontrolwindow.cpp
+++ b/keela-exe/cameracontrolwindow.cpp
@@ -80,9 +80,6 @@ Keela::CameraControlWindow::CameraControlWindow(const guint id, std::string pix_
     auto gl_bin = Gtk::make_managed<Gtk::Box>(Gtk::ORIENTATION_VERTICAL);
     h_container.pack_start(*gl_bin, false, false, 10);
 
-    // Initialize traces
-    update_traces();
-
     show_all_children();
     show();
 }
@@ -165,6 +162,11 @@ void Keela::CameraControlWindow::update_split_frame_state(bool should_split_fram
 }
 
 std::vector<std::shared_ptr<Keela::ITraceable>> Keela::CameraControlWindow::get_traces() {
+    // Lazily create traces if not already done
+    if (m_traces.empty()) {
+        update_traces();
+    }
+
     std::vector<std::shared_ptr<ITraceable>> traces;
     traces.reserve(m_traces.size());
     for (const auto& trace : m_traces) {

--- a/keela-exe/cameracontrolwindow.h
+++ b/keela-exe/cameracontrolwindow.h
@@ -70,6 +70,10 @@ namespace Keela {
 
     public:
         std::vector<std::shared_ptr<ITraceable>> get_traces();
+        void apply_trace_framerate(guint fps);
+        
+        // Callback for when traces are updated (e.g., frame splitting enabled/disabled)
+        std::function<void()> on_traces_updated_callback;
 
     private:
         std::vector<std::shared_ptr<CameraTrace>> m_traces;

--- a/keela-exe/cameracontrolwindow.h
+++ b/keela-exe/cameracontrolwindow.h
@@ -70,10 +70,7 @@ namespace Keela {
         void apply_trace_framerate(guint fps);
 
         // Method for main window to toggle split frame mode
-        void on_split_frames_changed(bool enabled);
-
-        // Callback for when traces are updated (e.g., frame splitting enabled/disabled)
-        std::function<void()> on_traces_updated_callback;
+        void update_split_frame_state(bool enabled);
 
     private:
         std::vector<std::shared_ptr<CameraTrace>> m_traces;

--- a/keela-exe/cameracontrolwindow.h
+++ b/keela-exe/cameracontrolwindow.h
@@ -18,7 +18,7 @@
 namespace Keela {
     class CameraControlWindow final : public Gtk::Window {
     public:
-        explicit CameraControlWindow(guint id, std::string pix_fmt);
+        explicit CameraControlWindow(guint id, std::string pix_fmt, bool should_split_frames);
 
         ~CameraControlWindow() override;
 
@@ -44,7 +44,6 @@ namespace Keela {
         Keela::LabeledComboBoxText rotation_combo = Keela::LabeledComboBoxText("Select Rotation");
         Gtk::CheckButton flip_horiz_check = Gtk::CheckButton("Flip Along Horizontal Center");
         Gtk::CheckButton flip_vert_check = Gtk::CheckButton("Flip Along Vertical Center");
-        Gtk::CheckButton split_frames_check = Gtk::CheckButton("Split Even/Odd Frames");
         Gtk::Button fetch_image_button = Gtk::Button("Fetch Image");
 
         std::shared_ptr<Keela::TraceGizmo> trace_gizmo_even;
@@ -60,8 +59,6 @@ namespace Keela {
 
         void on_flip_vert_changed() const;
 
-        void on_split_frames_changed();
-
         void add_split_frame_ui();
 
         void remove_split_frame_ui();
@@ -71,7 +68,10 @@ namespace Keela {
     public:
         std::vector<std::shared_ptr<ITraceable>> get_traces();
         void apply_trace_framerate(guint fps);
-        
+
+        // Method for main window to toggle split frame mode
+        void on_split_frames_changed(bool enabled);
+
         // Callback for when traces are updated (e.g., frame splitting enabled/disabled)
         std::function<void()> on_traces_updated_callback;
 

--- a/keela-exe/cameracontrolwindow.h
+++ b/keela-exe/cameracontrolwindow.h
@@ -9,13 +9,14 @@
 #include <keela-widgets/labeledspinbutton.h>
 
 #include "../keela-widgets/keela-widgets/cameramanager.h"
+#include "../keela-widgets/keela-widgets/cameratrace.h"
 #include "keela-widgets/GLCameraRender.h"
 #include "keela-widgets/GLTraceRender.h"
 #include "keela-widgets/tracegizmo.h"
 #include "keela-widgets/videopresentation.h"
 
 namespace Keela {
-    class CameraControlWindow final : public Gtk::Window, public Keela::ITraceable {
+    class CameraControlWindow final : public Gtk::Window {
     public:
         explicit CameraControlWindow(guint id);
 
@@ -47,6 +48,7 @@ namespace Keela {
         Gtk::Button fetch_image_button = Gtk::Button("Fetch Image");
 
         std::shared_ptr<Keela::TraceGizmo> trace_gizmo_even;
+        std::shared_ptr<Keela::TraceGizmo> trace_gizmo_odd;
         guint id;
 
         void on_range_check_toggled();
@@ -63,14 +65,13 @@ namespace Keela {
 
         void remove_split_frame_ui();
 
+        void update_traces();
+
     public:
-        std::shared_ptr<TraceBin> get_trace_bin() override;
-
-        std::shared_ptr<TraceGizmo> get_trace_gizmo() override;
-
-        std::string get_name() override;
+        std::vector<std::shared_ptr<ITraceable>> get_traces();
 
     private:
+        std::vector<std::shared_ptr<CameraTrace>> m_traces;
         // set width and height initially to a sentinel value
         int m_width = -1, m_height = -1;
     };

--- a/keela-exe/mainwindow.cpp
+++ b/keela-exe/mainwindow.cpp
@@ -54,19 +54,16 @@ MainWindow::MainWindow(): Gtk::Window() {
     dm_frame->add(data_matrix_h_spin);
     container.add(*dm_frame);
 
-    // calcium voltage recording setting control
+    // calcium voltage recording setting control, controls split frame logic
     cv_recording_check.set_label("Calcium-Voltage Recording Setting");
+    cv_recording_check.signal_toggled().connect(sigc::mem_fun(*this, &MainWindow::on_split_frames_changed));
+    cv_recording_check.set_active(should_split_frames);
     container.add(cv_recording_check);
 
     const auto camera_limits = Gtk::Adjustment::create(1.0, 1.0, std::numeric_limits<double>::max());
     num_camera_spin.m_spin.set_adjustment(camera_limits);
     num_camera_spin.m_spin.signal_value_changed().connect(sigc::mem_fun(*this, &MainWindow::on_camera_spin_changed));
     container.add(num_camera_spin);
-
-    // Add frame splitting control
-    split_frames_check.signal_toggled().connect(sigc::mem_fun(*this, &MainWindow::on_split_frames_changed));
-    split_frames_check.set_active(should_split_frames);
-    container.add(split_frames_check);
 
     show_trace_check.set_label("Show Traces");
     trace_fps_spin.m_spin.set_adjustment(Gtk::Adjustment::create(125, 1, 1000, 1));
@@ -288,7 +285,7 @@ void MainWindow::set_experiment_directory(std::shared_ptr<Keela::CameraControlWi
 }
 
 void MainWindow::on_split_frames_changed() {
-    should_split_frames = split_frames_check.get_active();
+    should_split_frames = cv_recording_check.get_active();
     spdlog::info("Frame splitting set to {}", should_split_frames);
 
     for (const auto &c : cameras) {

--- a/keela-exe/mainwindow.cpp
+++ b/keela-exe/mainwindow.cpp
@@ -290,7 +290,24 @@ void MainWindow::set_experiment_directory(std::shared_ptr<Keela::CameraControlWi
 void MainWindow::on_split_frames_changed() {
     should_split_frames = split_frames_check.get_active();
     spdlog::info("Frame splitting set to {}", should_split_frames);
+
     for (const auto &c : cameras) {
         c->update_split_frame_state(should_split_frames);
+    }
+    
+    // Update trace window if it's open
+    if (trace_window != nullptr) {
+        // Clear existing traces and re-add them based on new split frame state
+        trace_window = nullptr;
+        trace_window = std::make_unique<Keela::TraceWindow>();
+        trace_window->show();
+        
+        // Add all traces for all cameras, with the correct split state
+        for (const auto &camera : cameras) {
+            auto traces = camera->get_traces();
+            trace_window->addTraces(traces);
+        }
+        
+        trace_fps_spin.set_sensitive(true);
     }
 }

--- a/keela-exe/mainwindow.cpp
+++ b/keela-exe/mainwindow.cpp
@@ -113,14 +113,6 @@ void MainWindow::on_camera_spin_changed() {
             set_framerate(c->camera_manager.get());
             set_resolution(c.get());
 
-            // @todo: we will move the split frame management up a level to MainWindow and remove this cb
-            // Set up callback to apply trace framerate when traces are updated
-            c->on_traces_updated_callback = [this, c, camera_id]() {
-                const auto fps = static_cast<guint>(trace_fps_spin.m_spin.get_value());
-                c->apply_trace_framerate(fps);
-                spdlog::info("Applied trace framerate {} to camera {} after trace update", fps, camera_id);
-            };
-
             // Apply current trace framerate to new camera
             const auto fps = static_cast<guint>(trace_fps_spin.m_spin.get_value());
             c->apply_trace_framerate(fps);
@@ -299,6 +291,6 @@ void MainWindow::on_split_frames_changed() {
     should_split_frames = split_frames_check.get_active();
     spdlog::info("Frame splitting set to {}", should_split_frames);
     for (const auto &c : cameras) {
-        c->on_split_frames_changed(should_split_frames);
+        c->update_split_frame_state(should_split_frames);
     }
 }

--- a/keela-exe/mainwindow.cpp
+++ b/keela-exe/mainwindow.cpp
@@ -137,7 +137,7 @@ void MainWindow::on_camera_spin_changed() {
             gst_bin_remove(GST_BIN(pipeline), *camera_win->camera_manager);
             cameras.pop_back();
             if (trace_window != nullptr) {
-                trace_window->removeTrace();
+                trace_window->removeTraceRow();
             }
         }
     }
@@ -298,10 +298,10 @@ void MainWindow::on_split_frames_changed() {
     // Update trace window if it's open
     if (trace_window != nullptr) {
         // Clear existing traces and re-add them based on new split frame state
-        trace_window = nullptr;
-        trace_window = std::make_unique<Keela::TraceWindow>();
-        trace_window->show();
-        
+        while (trace_window->num_traces() > 0) {
+            trace_window->removeTraceRow();
+        }
+
         // Add all traces for all cameras, with the correct split state
         for (const auto &camera : cameras) {
             auto traces = camera->get_traces();

--- a/keela-exe/mainwindow.h
+++ b/keela-exe/mainwindow.h
@@ -32,7 +32,6 @@ private:
 
     Gtk::CheckButton cv_recording_check;
     Keela::LabeledSpinButton num_camera_spin = Keela::LabeledSpinButton("Number of Cameras");
-    Gtk::CheckButton split_frames_check = Gtk::CheckButton("Split Even/Odd Frames");
     Gtk::CheckButton show_trace_check;
     Keela::LabeledSpinButton trace_fps_spin = Keela::LabeledSpinButton("Trace Framerate (Hz)");
 

--- a/keela-exe/mainwindow.h
+++ b/keela-exe/mainwindow.h
@@ -32,6 +32,7 @@ private:
 
     Gtk::CheckButton cv_recording_check;
     Keela::LabeledSpinButton num_camera_spin = Keela::LabeledSpinButton("Number of Cameras");
+    Gtk::CheckButton split_frames_check = Gtk::CheckButton("Split Even/Odd Frames");
     Gtk::CheckButton show_trace_check;
     Keela::LabeledSpinButton trace_fps_spin = Keela::LabeledSpinButton("Trace Framerate (Hz)");
 
@@ -71,6 +72,10 @@ private:
     void set_experiment_directory(std::shared_ptr<Keela::CameraControlWindow> c) const;
 
     bool is_recording = false;
+
+    bool should_split_frames = false;
+
+    void on_split_frames_changed();
 
     void set_pix_fmt();
 };

--- a/keela-exe/tracewindow.cpp
+++ b/keela-exe/tracewindow.cpp
@@ -27,7 +27,7 @@ void Keela::TraceWindow::addTraces(const std::vector<std::shared_ptr<Keela::ITra
     for (const auto& trace : traces_to_add) {
         auto widget = std::make_shared<GLTraceRender>(trace);
         traces.push_back(widget);
-        row_box->pack_start(*widget, false, false, 0);
+        row_box->pack_start(*widget, true, true, 0);
     }
     
     container.pack_start(*row_box, false, false, 10);

--- a/keela-exe/tracewindow.cpp
+++ b/keela-exe/tracewindow.cpp
@@ -20,26 +20,40 @@ void Keela::TraceWindow::addTraces(const std::vector<std::shared_ptr<Keela::ITra
     if (traces_to_add.empty()) {
         return;
     }
-    
+
     // Create a horizontal box to hold traces from this camera
     auto row_box = Gtk::make_managed<Gtk::Box>(Gtk::ORIENTATION_HORIZONTAL);
     row_box->set_spacing(10);
-    
+
     for (const auto& trace : traces_to_add) {
         auto widget = std::make_shared<GLTraceRender>(trace);
         traces.push_back(widget);
         row_box->pack_start(*widget, true, true, 0);
     }
-    
+
     container.pack_start(*row_box, false, false, 10);
     show_all_children();
     spdlog::info("TraceWindow::{}: Added {} traces in a row", __func__, traces_to_add.size());
 }
 
-void Keela::TraceWindow::removeTrace() {
-    // TODO:
-    auto trace = std::move(traces.back());
-    traces.pop_back();
+void Keela::TraceWindow::removeTraceRow() {
+    // Get the most recently added row box
+    auto children = container.get_children();
+    if (!children.empty()) {
+        auto* last_row = children.back();
+        container.remove(*last_row);
+
+        // Count how many traces were in that last row
+        auto last_row_box = dynamic_cast<Gtk::Box*>(last_row);
+        int traces_in_last_row = last_row_box->get_children().size();
+
+        // Remove the corresponding number of traces
+        for (int i = 0; i < traces_in_last_row; i++) {
+            traces.pop_back();
+        }
+
+        spdlog::info("TraceWindow::{}: Removed last trace row with {} traces", __func__, traces_in_last_row);
+    }
 }
 
 int Keela::TraceWindow::num_traces() const {

--- a/keela-exe/tracewindow.cpp
+++ b/keela-exe/tracewindow.cpp
@@ -9,18 +9,30 @@ Keela::TraceWindow::TraceWindow() {
     set_default_size(640, 480);
     set_title("Traces");
     Window::add(scrolled_window);
-    scrolled_window.add(containter);
+    scrolled_window.add(container);
 }
 
 Keela::TraceWindow::~TraceWindow() {
 }
 
-void Keela::TraceWindow::addTrace(std::shared_ptr<Keela::ITraceable> trace) {
-    auto widget = std::make_shared<GLTraceRender>(trace);
-    traces.push_back(widget);
-    containter.add(*widget);
+void Keela::TraceWindow::addTraces(const std::vector<std::shared_ptr<Keela::ITraceable>>& traces_to_add) {
+    if (traces_to_add.empty()) {
+        return;
+    }
+    
+    // Create a horizontal box to hold traces from this camera
+    auto row_box = Gtk::make_managed<Gtk::Box>(Gtk::ORIENTATION_HORIZONTAL);
+    row_box->set_spacing(10);
+    
+    for (const auto& trace : traces_to_add) {
+        auto widget = std::make_shared<GLTraceRender>(trace);
+        traces.push_back(widget);
+        row_box->pack_start(*widget, false, false, 0);
+    }
+    
+    container.pack_start(*row_box, false, false, 10);
     show_all_children();
-    spdlog::info("TraceWindow::{}: Trace added", __func__);
+    spdlog::info("TraceWindow::{}: Added {} traces in a row", __func__, traces_to_add.size());
 }
 
 void Keela::TraceWindow::removeTrace() {

--- a/keela-exe/tracewindow.h
+++ b/keela-exe/tracewindow.h
@@ -20,7 +20,8 @@ namespace Keela {
 
         void addTraces(const std::vector<std::shared_ptr<Keela::ITraceable>>& traces);
 
-        void removeTrace();
+        /** A row contains all of the traces for one camera. */
+        void removeTraceRow();
 
         int num_traces() const;
 

--- a/keela-exe/tracewindow.h
+++ b/keela-exe/tracewindow.h
@@ -17,7 +17,7 @@ namespace Keela {
 
         ~TraceWindow() override;
 
-        void addTrace(std::shared_ptr<Keela::ITraceable> trace);
+        void addTraces(const std::vector<std::shared_ptr<Keela::ITraceable>>& traces);
 
         void removeTrace();
 
@@ -26,7 +26,7 @@ namespace Keela {
     private:
         std::vector<std::shared_ptr<GLTraceRender> > traces;
         Gtk::ScrolledWindow scrolled_window;
-        Gtk::Box containter = Gtk::Box(Gtk::ORIENTATION_VERTICAL);
+        Gtk::Box container = Gtk::Box(Gtk::ORIENTATION_VERTICAL);
     };
 }
 

--- a/keela-widgets/CMakeLists.txt
+++ b/keela-widgets/CMakeLists.txt
@@ -36,7 +36,9 @@ add_library(keela-widgets labeledspinbutton.cpp keela-widgets/labeledspinbutton.
         plugin_init.cpp
         plugin_init.h
         keela-widgets/videopresentation.h
-        videopresentation.cpp)
+        videopresentation.cpp
+        keela-widgets/cameratrace.h
+        cameratrace.cpp)
 add_dependencies(keela-widgets shader_resources)
 target_link_libraries(keela-widgets PUBLIC keela-pipeline PkgConfig::GTKMM PkgConfig::GIO PkgConfig::SPDLOG vendor-glad)
 target_include_directories(keela-widgets PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/keela-widgets/cameramanager.cpp
+++ b/keela-widgets/cameramanager.cpp
@@ -108,16 +108,18 @@ void Keela::CameraManager::start_recording() {
     record_bin_odd->set_directory(filename_odd);
 
     // Add both record bins to the pipeline
-    add_elements(static_cast<GstElement *>(*record_bin_even));
-    add_elements(static_cast<GstElement *>(*record_bin_odd));
+    add_elements(static_cast<Bin &>(*record_bin_even));
+    add_elements(static_cast<Bin &>(*record_bin_odd));
 
     // Sync state with parent
-    assert(gst_element_sync_state_with_parent(*record_bin_even));
-    assert(gst_element_sync_state_with_parent(*record_bin_odd));
+    gboolean sync_even_result = gst_element_sync_state_with_parent(static_cast<Bin &>(*record_bin_even));
+    gboolean sync_odd_result = gst_element_sync_state_with_parent(static_cast<Bin &>(*record_bin_odd));
+    assert(sync_even_result);
+    assert(sync_odd_result);
 
     // Link to both tees
-    element_link_many(tee_even, static_cast<GstElement *>(*record_bin_even));
-    element_link_many(tee_odd, static_cast<GstElement *>(*record_bin_odd));
+    element_link_many(tee_even, static_cast<Bin &>(*record_bin_even));
+    element_link_many(tee_odd, static_cast<Bin &>(*record_bin_odd));
 
     // Store both record bins
     record_bins.insert(record_bin_even);

--- a/keela-widgets/cameratrace.cpp
+++ b/keela-widgets/cameratrace.cpp
@@ -1,0 +1,18 @@
+#include "keela-widgets/cameratrace.h"
+
+Keela::CameraTrace::CameraTrace(std::shared_ptr<TraceBin> trace_bin,
+                                std::shared_ptr<TraceGizmo> trace_gizmo,
+                                const std::string& name)
+    : m_trace_bin(std::move(trace_bin)), m_trace_gizmo(std::move(trace_gizmo)), m_name(name) {}
+
+std::shared_ptr<Keela::TraceBin> Keela::CameraTrace::get_trace_bin() {
+    return m_trace_bin;
+}
+
+std::shared_ptr<Keela::TraceGizmo> Keela::CameraTrace::get_trace_gizmo() {
+    return m_trace_gizmo;
+}
+
+std::string Keela::CameraTrace::get_name() {
+    return m_name;
+}

--- a/keela-widgets/keela-widgets/cameratrace.h
+++ b/keela-widgets/keela-widgets/cameratrace.h
@@ -1,0 +1,29 @@
+#ifndef CAMERATRACE_H
+#define CAMERATRACE_H
+
+#include "GLTraceRender.h"
+
+namespace Keela {
+    /**
+     * CameraTrace is a simple implementation of ITraceable that holds references
+     * to a TraceBin and TraceGizmo. It acts as a data holder for trace components.
+     */
+    class CameraTrace final : public ITraceable {
+    public:
+        CameraTrace(std::shared_ptr<TraceBin> trace_bin,
+                    std::shared_ptr<TraceGizmo> trace_gizmo,
+                    const std::string& name);
+        ~CameraTrace() override = default;
+
+        std::shared_ptr<TraceBin> get_trace_bin() override;
+        std::shared_ptr<TraceGizmo> get_trace_gizmo() override;
+        std::string get_name() override;
+
+    private:
+        std::shared_ptr<TraceBin> m_trace_bin;
+        std::shared_ptr<TraceGizmo> m_trace_gizmo;
+        std::string m_name;
+    };
+}  // namespace Keela
+
+#endif  // CAMERATRACE_H


### PR DESCRIPTION
* Introduces a new `CameraTrace` class that implements `ITraceable`
* `CameraManager` no longer implements `ITraceable`, it manages a list of  `CameraTrace` elements. This allows us to dynamically have as many traceable elements as we want, per camera.