### PR TITLE
Ejectable Camera Streams

### DIFF
--- a/keela-exe/cameracontrolwindow.cpp
+++ b/keela-exe/cameracontrolwindow.cpp
@@ -52,8 +52,9 @@ Keela::CameraControlWindow::CameraControlWindow(const guint id, std::string pix_
     v_container.add(flip_vert_check);
 
     // TODO: dynamically cast camera_manager->presentation to a WidgetElement to get a handle to a widget to add to the window
+    // TODO: do we need to take a snapshot of the odd stream too? maybe not because we just need it for scale calibration?
     fetch_image_button.signal_clicked().connect(
-        sigc::mem_fun(camera_manager->snapshot, &Keela::SnapshotBin::take_snapshot));
+        sigc::mem_fun(*camera_manager->camera_stream_even->snapshot, &Keela::SnapshotBin::take_snapshot));
     v_container.add(fetch_image_button);
 
     set_vexpand(false);
@@ -64,7 +65,7 @@ Keela::CameraControlWindow::CameraControlWindow(const guint id, std::string pix_
     // Set up video presentations, frame_widget_even renders all frames unless split is enabled
     frame_widget_even = std::make_unique<VideoPresentation>(
         "Camera " + std::to_string(id),
-        camera_manager->presentation_even,
+        camera_manager->camera_stream_even->presentation,
         640, // width
         480 // height
     );
@@ -185,7 +186,7 @@ void Keela::CameraControlWindow::update_traces() {
     }
     
     auto even_trace = std::make_shared<CameraTrace>(
-        camera_manager->get_trace_even(),
+        camera_manager->camera_stream_even->get_trace(),
         trace_gizmo_even,
         even_name
     );
@@ -194,7 +195,7 @@ void Keela::CameraControlWindow::update_traces() {
     // Add odd trace if frame splitting is enabled
     if (camera_manager->is_frame_splitting_enabled() && trace_gizmo_odd) {
         auto odd_trace = std::make_shared<CameraTrace>(
-            camera_manager->get_trace_odd(),
+            camera_manager->camera_stream_odd->get_trace(),
             trace_gizmo_odd,
             "Camera " + std::to_string(id) + " (Odd)"
         );
@@ -222,14 +223,14 @@ void Keela::CameraControlWindow::add_split_frame_ui() {
     if (rotation == ROTATION_90 || rotation == ROTATION_270) {
         frame_widget_odd = std::make_unique<VideoPresentation>(
             "Odd Frames",
-            camera_manager->presentation_odd,
+            camera_manager->camera_stream_odd->presentation,
             480, // width
             640 // height
         );
     } else {
         frame_widget_odd = std::make_unique<VideoPresentation>(
             "Odd Frames",
-            camera_manager->presentation_odd,
+            camera_manager->camera_stream_odd->presentation,
             640, // width
             480 // height
         );

--- a/keela-pipeline/CMakeLists.txt
+++ b/keela-pipeline/CMakeLists.txt
@@ -29,6 +29,8 @@ add_library(keela-pipeline presentationbin.cpp keela-pipeline/presentationbin.h
         EjectableElement.cpp
         keela-pipeline/EjectableElement.h
         keela-pipeline/consts.h
+        CameraStreamBin.cpp
+        keela-pipeline/CameraStreamBin.h
 )
 target_link_libraries(keela-pipeline PUBLIC PkgConfig::GSTREAMER PkgConfig::SPDLOG)
 

--- a/keela-pipeline/CameraStreamBin.cpp
+++ b/keela-pipeline/CameraStreamBin.cpp
@@ -8,15 +8,9 @@
 
 #include "keela-pipeline/utils.h"
 
-Keela::CameraStreamBin::CameraStreamBin(const std::string &name) : QueueBin(name) {
-    spdlog::info("{}", __func__);
-    CameraStreamBin::init();
-
-    CameraStreamBin::link();
-}
-
-Keela::CameraStreamBin::CameraStreamBin() : QueueBin() {
-    spdlog::info("{}", __func__);
+Keela::CameraStreamBin::CameraStreamBin(const std::string &name) : QueueBin(name), name(name) {
+    spdlog::info("Creating CameraStreamBin: {}", name);
+    presentation = std::make_shared<PresentationBin>("presentation_" + this->name);
     CameraStreamBin::init();
     CameraStreamBin::link();
 }
@@ -26,14 +20,19 @@ Keela::CameraStreamBin::~CameraStreamBin() {
 }
 
 void Keela::CameraStreamBin::init() {
-    // g_object_set(sink, "max-buffers", 1, nullptr);
-    // g_object_set(sink, "drop", true, nullptr);
+    // Just configure elements, don't link yet
+    spdlog::info("Initializing CameraStreamBin {} elements", name);
 }
 
 void Keela::CameraStreamBin::link() {
-    // set_presentation_framerate(60);
-    // add_elements(video_rate, caps_filter, sink);
-    // element_link_many(video_rate, caps_filter, sink);
-    // link_queue(video_rate);
-    // add_ghost_pad(video_rate, "sink");
+    spdlog::info("Linking CameraStreamBin {} internal structure", name);
+
+    // Add internal tee and presentation to this bin (will add record, trace later)
+    add_elements(internal_tee, *presentation);
+
+    // Link internal_tee -> presentation  
+    element_link_many(internal_tee, *presentation);
+    link_queue(internal_tee);
+
+    spdlog::info("CameraStreamBin linked: queue -> tee -> presentation");
 }

--- a/keela-pipeline/CameraStreamBin.cpp
+++ b/keela-pipeline/CameraStreamBin.cpp
@@ -1,0 +1,39 @@
+#include "keela-pipeline/CameraStreamBin.h"
+
+#include <keela-pipeline/gtkglsink.h>
+#include <keela-pipeline/gtksink.h>
+#include <spdlog/spdlog.h>
+
+#include <stdexcept>
+
+#include "keela-pipeline/utils.h"
+
+Keela::CameraStreamBin::CameraStreamBin(const std::string &name) : QueueBin(name) {
+    spdlog::info("{}", __func__);
+    CameraStreamBin::init();
+
+    CameraStreamBin::link();
+}
+
+Keela::CameraStreamBin::CameraStreamBin() : QueueBin() {
+    spdlog::info("{}", __func__);
+    CameraStreamBin::init();
+    CameraStreamBin::link();
+}
+
+Keela::CameraStreamBin::~CameraStreamBin() {
+    spdlog::debug(__func__);
+}
+
+void Keela::CameraStreamBin::init() {
+    // g_object_set(sink, "max-buffers", 1, nullptr);
+    // g_object_set(sink, "drop", true, nullptr);
+}
+
+void Keela::CameraStreamBin::link() {
+    // set_presentation_framerate(60);
+    // add_elements(video_rate, caps_filter, sink);
+    // element_link_many(video_rate, caps_filter, sink);
+    // link_queue(video_rate);
+    // add_ghost_pad(video_rate, "sink");
+}

--- a/keela-pipeline/CameraStreamBin.cpp
+++ b/keela-pipeline/CameraStreamBin.cpp
@@ -11,6 +11,9 @@
 Keela::CameraStreamBin::CameraStreamBin(const std::string &name) : QueueBin(name), name(name) {
     spdlog::info("Creating CameraStreamBin: {}", name);
     presentation = std::make_shared<PresentationBin>("presentation_" + this->name);
+    snapshot = std::make_shared<SnapshotBin>("snapshot_" + this->name);
+    trace = std::make_shared<TraceBin>("trace_" + this->name);
+
     CameraStreamBin::init();
     CameraStreamBin::link();
 }
@@ -27,11 +30,13 @@ void Keela::CameraStreamBin::init() {
 void Keela::CameraStreamBin::link() {
     spdlog::info("Linking CameraStreamBin {} internal structure", name);
 
-    // Add internal tee and presentation to this bin (will add record, trace later)
-    add_elements(internal_tee, *presentation);
+    // Add internal tee and all child bins to this bin
+    add_elements(internal_tee, *presentation, *snapshot, *trace);
 
-    // Link internal_tee -> presentation  
+    // Link internal_tee -> all outputs
     element_link_many(internal_tee, *presentation);
+    element_link_many(internal_tee, *snapshot);
+    element_link_many(internal_tee, *trace);
     link_queue(internal_tee);
 
     spdlog::info("CameraStreamBin linked: queue -> tee -> presentation");

--- a/keela-pipeline/CameraStreamBin.cpp
+++ b/keela-pipeline/CameraStreamBin.cpp
@@ -14,17 +14,11 @@ Keela::CameraStreamBin::CameraStreamBin(const std::string &name) : QueueBin(name
     snapshot = std::make_shared<SnapshotBin>("snapshot_" + this->name);
     trace = std::make_shared<TraceBin>("trace_" + this->name);
 
-    CameraStreamBin::init();
     CameraStreamBin::link();
 }
 
 Keela::CameraStreamBin::~CameraStreamBin() {
     spdlog::debug(__func__);
-}
-
-void Keela::CameraStreamBin::init() {
-    // Just configure elements, don't link yet
-    spdlog::info("Initializing CameraStreamBin {} elements", name);
 }
 
 void Keela::CameraStreamBin::link() {
@@ -38,6 +32,4 @@ void Keela::CameraStreamBin::link() {
     element_link_many(internal_tee, *snapshot);
     element_link_many(internal_tee, *trace);
     link_queue(internal_tee);
-
-    spdlog::info("CameraStreamBin linked: queue -> tee -> presentation");
 }

--- a/keela-pipeline/keela-pipeline/CameraStreamBin.h
+++ b/keela-pipeline/keela-pipeline/CameraStreamBin.h
@@ -17,9 +17,13 @@ namespace Keela {
 
         ~CameraStreamBin() override;
 
+        SimpleElement internal_tee = SimpleElement("tee");
+
         std::shared_ptr<PresentationBin> presentation;
         std::shared_ptr<SnapshotBin> snapshot;
         std::shared_ptr<TraceBin> trace;
+
+        std::shared_ptr<TraceBin> get_trace() { return trace; }
 
     private:
         void init() override;
@@ -36,7 +40,6 @@ namespace Keela {
         }
 
         std::string name;
-        SimpleElement internal_tee = SimpleElement("tee");
     };
 }  // namespace Keela
 #endif  // CAMERASTREAMBIN_H

--- a/keela-pipeline/keela-pipeline/CameraStreamBin.h
+++ b/keela-pipeline/keela-pipeline/CameraStreamBin.h
@@ -1,0 +1,34 @@
+#ifndef CAMERASTREAMBIN_H
+#define CAMERASTREAMBIN_H
+
+
+#include "EjectableElement.h"
+#include "caps.h"
+#include "queuebin.h"
+#include "simpleelement.h"
+
+
+namespace Keela {
+    class CameraStreamBin final : public QueueBin, public EjectableElement {
+    public:
+        explicit CameraStreamBin(const std::string &name);
+
+        CameraStreamBin();
+
+        ~CameraStreamBin() override;
+
+        // Keela::SimpleElement sink = SimpleElement("appsink");
+
+    private:
+        void init() override;
+
+        void link() override;
+
+        /// Used to skip frames for the purposes of presentation
+        // Keela::SimpleElement video_rate = SimpleElement("videorate");
+        /// Controls the target presentation framerate
+        // Keela::SimpleElement caps_filter = SimpleElement("capsfilter");
+        // Keela::Caps presentation_caps = Caps();
+    };
+}  // namespace Keela
+#endif  // CAMERASTREAMBIN_H

--- a/keela-pipeline/keela-pipeline/CameraStreamBin.h
+++ b/keela-pipeline/keela-pipeline/CameraStreamBin.h
@@ -1,34 +1,38 @@
 #ifndef CAMERASTREAMBIN_H
 #define CAMERASTREAMBIN_H
 
+#include <keela-pipeline/presentationbin.h>
 
 #include "EjectableElement.h"
 #include "caps.h"
 #include "queuebin.h"
 #include "simpleelement.h"
 
-
 namespace Keela {
     class CameraStreamBin final : public QueueBin, public EjectableElement {
     public:
         explicit CameraStreamBin(const std::string &name);
 
-        CameraStreamBin();
-
         ~CameraStreamBin() override;
 
-        // Keela::SimpleElement sink = SimpleElement("appsink");
+        std::shared_ptr<PresentationBin> presentation;
 
     private:
         void init() override;
-
         void link() override;
 
-        /// Used to skip frames for the purposes of presentation
-        // Keela::SimpleElement video_rate = SimpleElement("videorate");
-        /// Controls the target presentation framerate
-        // Keela::SimpleElement caps_filter = SimpleElement("capsfilter");
-        // Keela::Caps presentation_caps = Caps();
+        Keela::Element *Head() override {
+            return &queue;
+        };
+
+        std::vector<Keela::Element *> Leaves() override {
+            std::vector<Keela::Element *> ret;
+            // @TODO: return any record_bins
+            return ret;
+        }
+
+        std::string name;
+        SimpleElement internal_tee = SimpleElement("tee");
     };
 }  // namespace Keela
 #endif  // CAMERASTREAMBIN_H

--- a/keela-pipeline/keela-pipeline/CameraStreamBin.h
+++ b/keela-pipeline/keela-pipeline/CameraStreamBin.h
@@ -3,6 +3,7 @@
 
 #include <keela-pipeline/presentationbin.h>
 #include <keela-pipeline/snapshotbin.h>
+#include <keela-pipeline/recordbin.h>
 
 #include "EjectableElement.h"
 #include "caps.h"
@@ -23,6 +24,12 @@ namespace Keela {
         std::shared_ptr<SnapshotBin> snapshot;
         std::shared_ptr<TraceBin> trace;
 
+        std::shared_ptr<RecordBin> record_bin = nullptr;
+        
+        void start_recording(const std::string& filename);
+
+        void stop_recording();
+
         std::shared_ptr<TraceBin> get_trace() { return trace; }
 
     private:
@@ -33,9 +40,7 @@ namespace Keela {
         };
 
         std::vector<Keela::Element *> Leaves() override {
-            std::vector<Keela::Element *> ret;
-            // @TODO: return any record_bins
-            return ret;
+            return std::vector<Keela::Element *>{record_bin.get()};
         }
 
         std::string name;

--- a/keela-pipeline/keela-pipeline/CameraStreamBin.h
+++ b/keela-pipeline/keela-pipeline/CameraStreamBin.h
@@ -2,9 +2,11 @@
 #define CAMERASTREAMBIN_H
 
 #include <keela-pipeline/presentationbin.h>
+#include <keela-pipeline/snapshotbin.h>
 
 #include "EjectableElement.h"
 #include "caps.h"
+#include "keela-pipeline/TraceBin.h"
 #include "queuebin.h"
 #include "simpleelement.h"
 
@@ -16,6 +18,8 @@ namespace Keela {
         ~CameraStreamBin() override;
 
         std::shared_ptr<PresentationBin> presentation;
+        std::shared_ptr<SnapshotBin> snapshot;
+        std::shared_ptr<TraceBin> trace;
 
     private:
         void init() override;

--- a/keela-pipeline/keela-pipeline/CameraStreamBin.h
+++ b/keela-pipeline/keela-pipeline/CameraStreamBin.h
@@ -40,7 +40,10 @@ namespace Keela {
         };
 
         std::vector<Keela::Element *> Leaves() override {
-            return std::vector<Keela::Element *>{record_bin.get()};
+            if (record_bin != nullptr) {
+                return std::vector<Keela::Element *>{record_bin.get()};
+            }
+            return std::vector<Keela::Element *>{};
         }
 
         std::string name;

--- a/keela-pipeline/keela-pipeline/CameraStreamBin.h
+++ b/keela-pipeline/keela-pipeline/CameraStreamBin.h
@@ -26,7 +26,6 @@ namespace Keela {
         std::shared_ptr<TraceBin> get_trace() { return trace; }
 
     private:
-        void init() override;
         void link() override;
 
         Keela::Element *Head() override {

--- a/keela-pipeline/keela-pipeline/snapshotbin.h
+++ b/keela-pipeline/keela-pipeline/snapshotbin.h
@@ -11,6 +11,8 @@
 namespace Keela {
     class SnapshotBin final : public Keela::QueueBin {
     public:
+        explicit SnapshotBin(const std::string &name);
+
         SnapshotBin();
 
         ~SnapshotBin() override;

--- a/keela-pipeline/keela-pipeline/snapshotbin.h
+++ b/keela-pipeline/keela-pipeline/snapshotbin.h
@@ -13,8 +13,6 @@ namespace Keela {
     public:
         explicit SnapshotBin(const std::string &name);
 
-        SnapshotBin();
-
         ~SnapshotBin() override;
 
         void take_snapshot();

--- a/keela-pipeline/snapshotbin.cpp
+++ b/keela-pipeline/snapshotbin.cpp
@@ -9,7 +9,7 @@
 #include "keela-pipeline/gst-helpers.h"
 #include "keela-pipeline/utils.h"
 
-Keela::SnapshotBin::SnapshotBin() {
+Keela::SnapshotBin::SnapshotBin(const std::string &name) : QueueBin(name) {
     SnapshotBin::init();
     SnapshotBin::link();
 }

--- a/keela-widgets/cameramanager.cpp
+++ b/keela-widgets/cameramanager.cpp
@@ -200,21 +200,9 @@ void Keela::CameraManager::set_frame_splitting(bool enabled) {
             camera_stream_odd = std::make_shared<CameraStreamBin>("camera_stream_odd");
         }
 
-        // camera_stream_odd = std::make_shared<CameraStreamBin>("camera_stream_odd");
         // Install the probes now that the pipeline is set up
         install_frame_splitting_probes();
-
-        // Only add odd camera stream if it hasn't been added yet
-        // Check if camera_stream_odd is already in the pipeline
-        Keela::Bin *camera_stream_bin = camera_stream_odd.get();
-        GstElement *camera_stream_elem_odd = static_cast<GstElement *>(*camera_stream_bin);
-        GstObject *parent = gst_element_get_parent(camera_stream_elem_odd);
-        if (!parent) {
-            add_odd_camera_stream();
-        } else {
-            g_object_unref(parent);
-            spdlog::info("camera_stream_odd already in pipeline, skipping add");
-        }
+        add_odd_camera_stream();
     } else {
         // Remove probes so the even stream gets all frames
         remove_frame_splitting_probes();
@@ -296,14 +284,10 @@ void Keela::CameraManager::add_odd_camera_stream() {
 }
 
 void Keela::CameraManager::remove_probe_by_id(gulong &probe_id, GstPad *pad, const std::string &probe_name) {
-    if (probe_id != 0) {
-        if (pad) {
-            gst_pad_remove_probe(pad, probe_id);
-            g_object_unref(pad);
-            probe_id = 0;
-            spdlog::info("Removed {} probe", probe_name);
-        }
-    }
+    gst_pad_remove_probe(pad, probe_id);
+    g_object_unref(pad);
+    probe_id = 0;
+    spdlog::info("Removed {} probe", probe_name);
 }
 
 void Keela::CameraManager::remove_frame_splitting_probes() {

--- a/keela-widgets/cameramanager.cpp
+++ b/keela-widgets/cameramanager.cpp
@@ -25,8 +25,8 @@ Keela::CameraManager::CameraManager(guint id, std::string pix_fmt, bool split_st
         // Add all elements to the bin (except camera_stream_even which has deleted copy constructor)
         add_elements(camera, caps_filter, transform,
                      tee_main, tee_even, tee_odd,
-                     *trace_even, *presentation_even, snapshot_even,
-                     *trace_odd, *presentation_odd, snapshot_odd);
+                     *trace_even, *presentation_even, *snapshot_even,
+                     *trace_odd, *presentation_odd, *snapshot_odd);
 
         // Add camera_stream_even manually due to deleted copy constructor from multiple inheritance
         // Cast to Bin base class first to resolve ambiguous conversion
@@ -54,12 +54,12 @@ Keela::CameraManager::CameraManager(guint id, std::string pix_fmt, bool split_st
 
         // Link even frame outputs
         element_link_many(tee_even, *presentation_even);
-        element_link_many(tee_even, snapshot_even);
+        element_link_many(tee_even, *snapshot_even);
         element_link_many(tee_even, *trace_even);
 
         // Link odd frame outputs
         element_link_many(tee_odd, *presentation_odd);
-        element_link_many(tee_odd, snapshot_odd);
+        element_link_many(tee_odd, *snapshot_odd);
         element_link_many(tee_odd, *trace_odd);
 
         // Set up frame splitting if enabled

--- a/keela-widgets/cameramanager.cpp
+++ b/keela-widgets/cameramanager.cpp
@@ -283,13 +283,11 @@ void Keela::CameraManager::add_odd_camera_stream() {
     if (!ret) {
         throw std::runtime_error("Failed to add camera_stream_odd to bin");
     }
-
     // Sync state with parent if the pipeline is already running
     gboolean sync_result = gst_element_sync_state_with_parent(camera_stream_elem_odd);
     if (!sync_result) {
         spdlog::warn("Failed to sync camera_stream_odd state with parent");
     }
-
     // Link main tee to camera_stream_odd manually using gst_element_link
     gboolean link_result = gst_element_link(tee_main, camera_stream_elem_odd);
     if (!link_result) {

--- a/keela-widgets/cameramanager.cpp
+++ b/keela-widgets/cameramanager.cpp
@@ -137,8 +137,6 @@ GstPadProbeReturn Keela::CameraManager::frame_parity_probe_cb(GstPad *pad, GstPa
 void Keela::CameraManager::set_frame_splitting(bool enabled) {
     split_streams = enabled;
     spdlog::info("Frame splitting {}", enabled ? "enabled" : "disabled");
-    // Reset frame counter when toggling
-    frame_count.store(0);
 
     if (enabled) {
         if (camera_stream_odd == nullptr) {

--- a/keela-widgets/keela-widgets/cameramanager.h
+++ b/keela-widgets/keela-widgets/cameramanager.h
@@ -4,6 +4,7 @@
 
 #ifndef CAMERAMANAGER_H
 #define CAMERAMANAGER_H
+#include <keela-pipeline/CameraStreamBin.h>
 #include <keela-pipeline/bin.h>
 #include <keela-pipeline/caps.h>
 #include <keela-pipeline/presentationbin.h>
@@ -40,6 +41,9 @@ namespace Keela {
         void set_frame_splitting(bool enabled);
 
         bool is_frame_splitting_enabled() const { return split_streams; }
+
+        // Camera Streams manage presentation, recording, and tracing of their respective frame streams
+        std::shared_ptr<CameraStreamBin> camera_stream_even = std::make_shared<CameraStreamBin>("camera_stream_even");
 
         // Get trace bins for both even and odd paths
         std::shared_ptr<TraceBin> get_trace_even() { return trace_even; }

--- a/keela-widgets/keela-widgets/cameramanager.h
+++ b/keela-widgets/keela-widgets/cameramanager.h
@@ -18,6 +18,9 @@
 
 #include "keela-pipeline/TraceBin.h"
 
+#define EVEN_FRAME 0
+#define ODD_FRAME 1
+
 namespace Keela {
     class CameraManager final : public Keela::Bin {
     public:
@@ -51,7 +54,6 @@ namespace Keela {
         TransformBin transform = TransformBin("transform");
 
     private:
-        gulong frame_numbering_probe_id = 0;
         gulong even_frame_probe_id = 0;
         gulong odd_frame_probe_id = 0;
 
@@ -63,12 +65,8 @@ namespace Keela {
 
         void remove_probe_by_id(gulong &probe_id, GstPad *pad, const std::string &probe_name);
 
-        // Frame filtering callbacks
-        static GstPadProbeReturn frame_numbering_probe_cb(GstPad *pad, GstPadProbeInfo *info, gpointer user_data);
-
-        static GstPadProbeReturn even_frame_probe_cb(GstPad *pad, GstPadProbeInfo *info, gpointer user_data);
-
-        static GstPadProbeReturn odd_frame_probe_cb(GstPad *pad, GstPadProbeInfo *info, gpointer user_data);
+        // Frame filtering callback
+        static GstPadProbeReturn frame_parity_probe_cb(GstPad *pad, GstPadProbeInfo *info, gpointer user_data);
 
         guint id;
         bool split_streams;

--- a/keela-widgets/keela-widgets/cameramanager.h
+++ b/keela-widgets/keela-widgets/cameramanager.h
@@ -71,9 +71,6 @@ namespace Keela {
         guint id;
         bool split_streams;
 
-        // Frame counting for even/odd filtering
-        std::atomic<guint64> frame_count{0};
-
         /// caps filter to apply to the entire stream
         Caps base_caps;
 

--- a/keela-widgets/keela-widgets/cameramanager.h
+++ b/keela-widgets/keela-widgets/cameramanager.h
@@ -44,27 +44,12 @@ namespace Keela {
 
         // Camera Streams manage presentation, recording, and tracing of their respective frame streams
         std::shared_ptr<CameraStreamBin> camera_stream_even = std::make_shared<CameraStreamBin>("camera_stream_even");
-
-        // Get trace bins for both even and odd paths
-        std::shared_ptr<TraceBin> get_trace_even() { return trace_even; }
-        std::shared_ptr<TraceBin> get_trace_odd() { return trace_odd; }
+        std::shared_ptr<CameraStreamBin> camera_stream_odd = std::make_shared<CameraStreamBin>("camera_stream_odd");
 
         SimpleElement camera = SimpleElement("videotestsrc");
         SimpleElement caps_filter = SimpleElement("capsfilter");
         TransformBin transform = TransformBin("transform");
 
-        // Even frame path
-        std::shared_ptr<PresentationBin> presentation_even = std::make_shared<PresentationBin>("presentation_even");
-        std::shared_ptr<SnapshotBin> snapshot_even = std::make_shared<SnapshotBin>("snapshot_even");
-        std::shared_ptr<TraceBin> trace_even = std::make_shared<TraceBin>("trace_even");
-
-        // Odd frame path
-        std::shared_ptr<PresentationBin> presentation_odd = std::make_shared<PresentationBin>("presentation_odd");
-        std::shared_ptr<SnapshotBin> snapshot_odd = std::make_shared<SnapshotBin>("snapshot_odd");
-        std::shared_ptr<TraceBin> trace_odd = std::make_shared<TraceBin>("trace_odd");
-
-        SnapshotBin &snapshot = *snapshot_even;
-        std::shared_ptr<TraceBin> &trace = trace_even;
 
     private:
         void set_up_frame_splitting();
@@ -100,16 +85,6 @@ namespace Keela {
          */
         SimpleElement tee_main = SimpleElement("tee");
 
-        /**
-         * use to split even frames to multiple outputs
-         */
-        SimpleElement tee_even = SimpleElement("tee");
-
-        /**
-         * use to split odd frames to multiple outputs
-         */
-        SimpleElement tee_odd = SimpleElement("tee");
-
         /* at any moment there may be many active record bins
          *
          * TODO: do these still need to be shared_ptr?
@@ -124,6 +99,8 @@ namespace Keela {
          * supports cross-platform path joining
          */
         static std::string get_filename(std::string directory, guint cam_id, std::string suffix = "");
+
+        void add_odd_camera_stream();
     };
 } // namespace Keela
 #endif  // CAMERAMANAGER_H

--- a/keela-widgets/keela-widgets/cameramanager.h
+++ b/keela-widgets/keela-widgets/cameramanager.h
@@ -50,11 +50,18 @@ namespace Keela {
         SimpleElement caps_filter = SimpleElement("capsfilter");
         TransformBin transform = TransformBin("transform");
 
-
     private:
+        gulong frame_numbering_probe_id = 0;
+        gulong even_frame_probe_id = 0;
+        gulong odd_frame_probe_id = 0;
+
         void set_up_frame_splitting();
 
         void install_frame_splitting_probes();
+
+        void remove_frame_splitting_probes();
+
+        void remove_probe_by_id(gulong &probe_id, GstPad *pad, const std::string &probe_name);
 
         // Frame filtering callbacks
         static GstPadProbeReturn frame_numbering_probe_cb(GstPad *pad, GstPadProbeInfo *info, gpointer user_data);
@@ -102,5 +109,5 @@ namespace Keela {
 
         void add_odd_camera_stream();
     };
-} // namespace Keela
+}  // namespace Keela
 #endif  // CAMERAMANAGER_H

--- a/keela-widgets/keela-widgets/cameramanager.h
+++ b/keela-widgets/keela-widgets/cameramanager.h
@@ -55,15 +55,15 @@ namespace Keela {
 
         // Even frame path
         std::shared_ptr<PresentationBin> presentation_even = std::make_shared<PresentationBin>("presentation_even");
-        SnapshotBin snapshot_even;
+        std::shared_ptr<SnapshotBin> snapshot_even = std::make_shared<SnapshotBin>("snapshot_even");
         std::shared_ptr<TraceBin> trace_even = std::make_shared<TraceBin>("trace_even");
 
         // Odd frame path
         std::shared_ptr<PresentationBin> presentation_odd = std::make_shared<PresentationBin>("presentation_odd");
-        SnapshotBin snapshot_odd;
+        std::shared_ptr<SnapshotBin> snapshot_odd = std::make_shared<SnapshotBin>("snapshot_odd");
         std::shared_ptr<TraceBin> trace_odd = std::make_shared<TraceBin>("trace_odd");
 
-        SnapshotBin &snapshot = snapshot_even;
+        SnapshotBin &snapshot = *snapshot_even;
         std::shared_ptr<TraceBin> &trace = trace_even;
 
     private:


### PR DESCRIPTION
This PR:
* adds a `CameraStreamBin` that is responsible for managing the presentation, recording, and tracing of a Camera Stream. A camera stream can be the normal video data, or a split stream of only even, or odd frames if the split frame logic is enabled.
* we only create the "odd" camera stream if split frame is enabled, and since `CameraStreamBin` implements `EjectableElement`, we can easily switch between split and joined streams.
* pull recording logic from CameraManager into CameraStreamBin

Other Changes:
* removed the "frame numbering probe", it turns out this logic wasn't being called, and the GstBuffer offset is already the frame number by default ([source](https://gstreamer.freedesktop.org/documentation/gstreamer/gstbuffer.html?gi-language=c#:~:text=For%20video%20buffers%2C%20the%20start%20offset%20will%20generally%20be%20the%20frame%20number.))
* DRYs up the frame filtering logic, the only difference between the even and odd frame probe callbacks was the parity checker (0 vs 1)

Left To Do:
* clean up the logic around adding camera streams to the bin and linking them to the main tee once we land https://github.com/Evan-Hartley/Keela/pull/30

## Bin Dump Graphs 

default/on load:
<img width="2083" height="600" alt="image" src="https://github.com/user-attachments/assets/fa2fc556-371d-4124-8f7e-faa74f8919e2" />

post split:
<img width="2127" height="1044" alt="image" src="https://github.com/user-attachments/assets/7945c9ac-3f03-4d87-940c-51cdc07b6c81" />

post un-split:
<img width="2111" height="567" alt="image" src="https://github.com/user-attachments/assets/dd61c303-08dc-48f9-af79-b50e7edfe02e" />

