### PR TITLE
remove redundant implementation of gst_bin_add_many

### DIFF
--- a/keela-pipeline/keela-pipeline/bin.h
+++ b/keela-pipeline/keela-pipeline/bin.h
@@ -5,10 +5,8 @@
 #ifndef BIN_H
 #define BIN_H
 #include <memory>
-#include <stdexcept>
 #include <string>
 #include <gstreamer-1.0/gst/gst.h>
-#include <spdlog/spdlog.h>
 
 #include "elementbase.h"
 
@@ -17,11 +15,9 @@ namespace Keela {
     public:
         explicit Bin(const std::string &name);
 
-        //Bin(const Bin &bin);
         Bin();
 
         ~Bin() override;
-
 
         operator GstElement *() const override;
 
@@ -37,24 +33,23 @@ namespace Keela {
             gst_bin_add_many(static_cast<GstBin *>(*this), static_cast<GstElement *>(elements)..., nullptr);
         }
 
-    protected
-    :
+    protected:
         std::shared_ptr<GstBin> bin;
-        //GstBin *bin;
 
         /**
          * Create a ghost pad for an internal GstElement
          */
         void add_ghost_pad(GstElement *element, const std::string &pad_name) const;
 
-    private
-    :
-        /* Create required elements and add them to the bin
+    private:
+        /*
+         * Create required elements and add them to the bin
          */
         virtual void init() {
         };
 
-        /* Link elements together
+        /*
+         * Link elements together
          */
         virtual void link() {
         }

--- a/keela-pipeline/keela-pipeline/bin.h
+++ b/keela-pipeline/keela-pipeline/bin.h
@@ -30,30 +30,15 @@ namespace Keela {
         /// dump the bin data to a graphviz graph
         void dump_bin_graph() const;
 
-        /**
-         * use this function to add many elements to the bin. If we use `gst_bin_add_many` directly,
-         * temporaries will be created using the implicit copy constructor which will mess up the underlying
-         * `GstElement` refcount.
-         * @tparam First any type which can convert to GstElement*
-         */
-        template<typename First, typename... Rest>
-        void add_elements(First first, Rest... rest) {
-            GstElement *e = first;
 
-            gst_object_ref(e);
-            GstElement *b = *this;
-            auto ret = gst_bin_add(GST_BIN(b), GST_ELEMENT(e));
-            if (!ret) {
-                throw std::runtime_error("Failed to add element to bin");
-            }
-            add_elements(rest...);
+        /// add many elements to the current bin
+        template<typename... Elements>
+        void add_elements(Elements... elements) {
+            gst_bin_add_many(static_cast<GstBin *>(*this), static_cast<GstElement *>(elements)..., nullptr);
         }
 
-        static void add_elements() {
-            spdlog::info("{} Added all elements to bin", __func__);
-        };
-
-    protected:
+    protected
+    :
         std::shared_ptr<GstBin> bin;
         //GstBin *bin;
 
@@ -62,7 +47,8 @@ namespace Keela {
          */
         void add_ghost_pad(GstElement *element, const std::string &pad_name) const;
 
-    private:
+    private
+    :
         /* Create required elements and add them to the bin
          */
         virtual void init() {


### PR DESCRIPTION
`Keela::Bin::add_elements` was more complicated than it needed to be. 

I believe this should help a bit to prevent us from having to cast elements to `GstElement *` at the call site of this function