### PR TITLE
Allow disabling traces with the close button

### DIFF
--- a/keela-exe/mainwindow.h
+++ b/keela-exe/mainwindow.h
@@ -40,6 +40,7 @@ private:
     Gtk::Box container;
     std::vector<std::shared_ptr<Keela::CameraControlWindow> > cameras;
     std::shared_ptr<Keela::TraceWindow> trace_window = nullptr;
+    sigc::connection trace_signal_connection;
 
     void on_camera_spin_changed();
 

--- a/keela-exe/tracewindow.cpp
+++ b/keela-exe/tracewindow.cpp
@@ -5,7 +5,8 @@
 #include "tracewindow.h"
 
 Keela::TraceWindow::TraceWindow() {
-    set_deletable(false);
+    signal_delete_event().connect(sigc::mem_fun(this, &TraceWindow::on_delete_event));
+
     set_default_size(640, 480);
     set_title("Traces");
     Window::add(scrolled_window);
@@ -60,9 +61,21 @@ int Keela::TraceWindow::num_traces() const {
     return traces.size();
 }
 
+void Keela::TraceWindow::set_on_closed_callback(std::function<void()> callback) {
+    on_window_closed_callback = std::move(callback);
+}
+
 bool Keela::TraceWindow::on_timeout() {
     for (const auto &trace: traces) {
         trace->queue_draw();
     }
     return true;
 }
+
+bool Keela::TraceWindow::on_delete_event(GdkEventAny* any_event) {
+    if (on_window_closed_callback) {
+        on_window_closed_callback();
+    }
+    return false; // Allow the default handler to destroy the window
+}
+

--- a/keela-exe/tracewindow.h
+++ b/keela-exe/tracewindow.h
@@ -25,6 +25,9 @@ namespace Keela {
 
         int num_traces() const;
 
+        /** Callback passed by the MainWindow to update "Show Traces" UI when we close the trace window */
+        void set_on_closed_callback(std::function<void()> callback);
+
     private:
         std::vector<std::shared_ptr<GLTraceRender> > traces;
         Gtk::ScrolledWindow scrolled_window;
@@ -32,6 +35,9 @@ namespace Keela {
 
         // sync up queueing draw events for trace widgets
         bool on_timeout();
+
+        std::function<void()> on_window_closed_callback;
+        bool on_delete_event(GdkEventAny* any_event);
     };
 }
 


### PR DESCRIPTION
This PR allows for deactivating the "Show Traces" feature by closing the trace window itself.

The `MainWindow` passes a cleanup callback that is transferred to the `TraceWindow`, to be executed when the `signal_delete_event` fires.

We block the `show_trace_check.signal_clicked()` connection in this callback to prevent a recursive loop when closing the window.


https://github.com/user-attachments/assets/c7139ef9-1b48-4064-bf9c-47d803e73016



