### PR TITLE
Gain/Exposure control for Aravis Cameras

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ pkg_search_module(GTKMM REQUIRED IMPORTED_TARGET gtkmm-3.0)
 pkg_search_module(GSTREAMER REQUIRED IMPORTED_TARGET gstreamer-1.0)
 pkg_search_module(SPDLOG REQUIRED IMPORTED_TARGET spdlog)
 pkg_search_module(GIO REQUIRED IMPORTED_TARGET gio-2.0)
+pkg_search_module(ARAVIS REQUIRED IMPORTED_TARGET aravis-0.8)
 
 # compile the keela-videotestsrc plugin if enabled
 if (ENABLE_KEELA_VIDEOTESTSRC)

--- a/keela-exe/cameracontrolwindow.cpp
+++ b/keela-exe/cameracontrolwindow.cpp
@@ -34,11 +34,15 @@ Keela::CameraControlWindow::CameraControlWindow(const guint id, std::string pix_
     range_frame->add(range_max_spin);
     v_container.add(*range_frame);
 
-    
     // Disable gain control until camera is ready and we can query for gain support and supported range
     gain_spin.m_spin.set_sensitive(false);
     gain_spin.m_spin.signal_value_changed().connect(sigc::mem_fun(*this, &CameraControlWindow::on_gain_changed));
     v_container.add(gain_spin);
+
+    // Disable exposure time control until camera is ready and we can query for exposure time support and supported range
+    exposure_time_spin.m_spin.set_sensitive(false);
+    exposure_time_spin.m_spin.signal_value_changed().connect(sigc::mem_fun(*this, &CameraControlWindow::on_exposure_time_changed));
+    v_container.add(exposure_time_spin);
 
     // TODO: add rotation options
     rotation_combo.m_combo.signal_changed().connect(sigc::mem_fun(*this, &CameraControlWindow::on_rotation_changed));
@@ -69,8 +73,8 @@ Keela::CameraControlWindow::CameraControlWindow(const guint id, std::string pix_
     frame_widget_even = std::make_unique<VideoPresentation>(
         "Camera " + std::to_string(id),
         camera_manager->camera_stream_even->presentation,
-        640, // width
-        480 // height
+        640,  // width
+        480   // height
     );
     frame_widget_even->add_overlay_widget(*trace_gizmo_even);
     video_hbox.pack_start(*frame_widget_even, false, false, 10);
@@ -102,6 +106,12 @@ void Keela::CameraControlWindow::on_gain_changed() const {
     const auto gain = gain_spin.m_spin.get_value();
     spdlog::info("Gain changed to {}", gain);
     camera_manager->set_gain(gain);
+}
+
+void Keela::CameraControlWindow::on_exposure_time_changed() const {
+    const auto exposure_time = exposure_time_spin.m_spin.get_value();
+    spdlog::info("Exposure time changed to {}", exposure_time);
+    camera_manager->set_exposure_time(exposure_time);
 }
 
 void Keela::CameraControlWindow::set_resolution(const int width, const int height) {
@@ -187,34 +197,32 @@ std::vector<std::shared_ptr<Keela::ITraceable>> Keela::CameraControlWindow::get_
 
 void Keela::CameraControlWindow::update_traces() {
     m_traces.clear();
-    
+
     // Always add the even trace
     std::string even_name = "Camera " + std::to_string(id);
     if (camera_manager->is_frame_splitting_enabled()) {
         even_name += " (Even)";
     }
-    
+
     auto even_trace = std::make_shared<CameraTrace>(
         camera_manager->camera_stream_even->get_trace(),
         trace_gizmo_even,
-        even_name
-    );
+        even_name);
     m_traces.push_back(even_trace);
-    
+
     // Add odd trace if frame splitting is enabled
     if (camera_manager->is_frame_splitting_enabled() && trace_gizmo_odd) {
         auto odd_trace = std::make_shared<CameraTrace>(
             camera_manager->camera_stream_odd->get_trace(),
             trace_gizmo_odd,
-            "Camera " + std::to_string(id) + " (Odd)"
-        );
+            "Camera " + std::to_string(id) + " (Odd)");
         m_traces.push_back(odd_trace);
     }
 }
 
 void Keela::CameraControlWindow::apply_trace_framerate(guint fps) {
     spdlog::info("Applying trace framerate {} to all traces for camera {}", fps, id);
-    for (const auto &trace : m_traces) {
+    for (const auto& trace : m_traces) {
         auto trace_bin = trace->get_trace_bin();
         if (trace_bin) {
             trace_bin->set_trace_framerate(fps);
@@ -223,7 +231,7 @@ void Keela::CameraControlWindow::apply_trace_framerate(guint fps) {
 }
 
 void Keela::CameraControlWindow::add_split_frame_ui() {
-    if (frame_widget_odd) return; // Already added
+    if (frame_widget_odd) return;  // Already added
 
     // Create trace gizmo for odd frames
     trace_gizmo_odd = std::make_shared<TraceGizmo>();
@@ -233,15 +241,15 @@ void Keela::CameraControlWindow::add_split_frame_ui() {
         frame_widget_odd = std::make_unique<VideoPresentation>(
             "Odd Frames",
             camera_manager->camera_stream_odd->presentation,
-            480, // width
-            640 // height
+            480,  // width
+            640   // height
         );
     } else {
         frame_widget_odd = std::make_unique<VideoPresentation>(
             "Odd Frames",
             camera_manager->camera_stream_odd->presentation,
-            640, // width
-            480 // height
+            640,  // width
+            480   // height
         );
     }
 
@@ -273,7 +281,7 @@ void Keela::CameraControlWindow::update_gain_range() {
     auto gain_range = camera_manager->get_gain_range();
     double min_gain = gain_range.first;
     double max_gain = gain_range.second;
-    
+
     if (min_gain == 0.0 && max_gain == 0.0) {
         gain_spin.m_spin.set_sensitive(false);
         spdlog::warn("Gain control not supported by camera - disabling gain control UI");
@@ -282,6 +290,24 @@ void Keela::CameraControlWindow::update_gain_range() {
     // update the gain spin with the new range
     gain_spin.m_spin.set_adjustment(Gtk::Adjustment::create(min_gain, min_gain, max_gain, 1.0));
     gain_spin.m_spin.set_sensitive(true);
-    
+
     spdlog::info("Updated gain control range to {:.1f} - {:.1f} dB", min_gain, max_gain);
+}
+
+void Keela::CameraControlWindow::update_exposure_time_range() {
+    // get the range supported by the camera hardware
+    auto exposure_time_range = camera_manager->get_exposure_time_range();
+    double min_exposure_time = exposure_time_range.first;
+    double max_exposure_time = exposure_time_range.second;
+
+    if (min_exposure_time == 0.0 && max_exposure_time == 0.0) {
+        exposure_time_spin.m_spin.set_sensitive(false);
+        spdlog::warn("Exposure time control not supported by camera - disabling exposure time control UI");
+        return;
+    }
+    // update the exposure time spin with the new range
+    exposure_time_spin.m_spin.set_adjustment(Gtk::Adjustment::create(min_exposure_time, min_exposure_time, max_exposure_time, 1000.0));
+    exposure_time_spin.m_spin.set_sensitive(true);
+
+    spdlog::info("Updated exposure time control range to {:.1f} - {:.1f} μs", min_exposure_time, max_exposure_time);
 }

--- a/keela-exe/cameracontrolwindow.h
+++ b/keela-exe/cameracontrolwindow.h
@@ -39,7 +39,7 @@ namespace Keela {
         Keela::LabeledSpinButton range_max_spin = Keela::LabeledSpinButton("Maximum");
 
         // TODO: histogram
-        Keela::LabeledSpinButton gain_spin = Keela::LabeledSpinButton("Gain");
+        Keela::LabeledSpinButton gain_spin = Keela::LabeledSpinButton("Gain (dB)");
 
         Keela::LabeledComboBoxText rotation_combo = Keela::LabeledComboBoxText("Select Rotation");
         Gtk::CheckButton flip_horiz_check = Gtk::CheckButton("Flip Along Horizontal Center");
@@ -52,6 +52,8 @@ namespace Keela {
         guint id;
 
         void on_range_check_toggled();
+
+        void on_gain_changed() const;
 
         void on_rotation_changed();
 
@@ -71,6 +73,9 @@ namespace Keela {
 
         // Method for main window to toggle split frame mode
         void update_split_frame_state(bool enabled);
+        
+        // Update gain range after camera is ready
+        void update_gain_range();
 
     private:
         std::vector<std::shared_ptr<CameraTrace>> m_traces;

--- a/keela-exe/cameracontrolwindow.h
+++ b/keela-exe/cameracontrolwindow.h
@@ -40,6 +40,7 @@ namespace Keela {
 
         // TODO: histogram
         Keela::LabeledSpinButton gain_spin = Keela::LabeledSpinButton("Gain (dB)");
+        Keela::LabeledSpinButton exposure_time_spin = Keela::LabeledSpinButton("Exposure Time (μs)");
 
         Keela::LabeledComboBoxText rotation_combo = Keela::LabeledComboBoxText("Select Rotation");
         Gtk::CheckButton flip_horiz_check = Gtk::CheckButton("Flip Along Horizontal Center");
@@ -54,6 +55,8 @@ namespace Keela {
         void on_range_check_toggled();
 
         void on_gain_changed() const;
+
+        void on_exposure_time_changed() const;
 
         void on_rotation_changed();
 
@@ -76,6 +79,9 @@ namespace Keela {
         
         // Update gain range after camera is ready
         void update_gain_range();
+
+        // Update exposure time range after camera is ready
+        void update_exposure_time_range();
 
     private:
         std::vector<std::shared_ptr<CameraTrace>> m_traces;

--- a/keela-exe/mainwindow.cpp
+++ b/keela-exe/mainwindow.cpp
@@ -95,6 +95,7 @@ MainWindow::MainWindow(): Gtk::Window() {
     Glib::signal_timeout().connect_once([this]() {
         for (const auto &camera : cameras) {
             camera->update_gain_range();
+            camera->update_exposure_time_range();
         }
     }, 1000);  // 1 second delay
 

--- a/keela-exe/mainwindow.cpp
+++ b/keela-exe/mainwindow.cpp
@@ -5,6 +5,7 @@
 #include "mainwindow.h"
 
 #include <keela-widgets/labeledspinbutton.h>
+#include <keela-widgets/plugin_utils.h>
 #include <spdlog/spdlog.h>
 
 #include "cameracontrolwindow.h"
@@ -88,6 +89,15 @@ MainWindow::MainWindow(): Gtk::Window() {
     // Initialize recording settings here
     on_camera_spin_changed();
     gst_element_set_state(GST_ELEMENT(pipeline), GST_STATE_PLAYING);
+
+    // @todo: implement a callback to update the gain range after the camera is ready
+    //        this is just to get help get started for now
+    Glib::signal_timeout().connect_once([this]() {
+        for (const auto &camera : cameras) {
+            camera->update_gain_range();
+        }
+    }, 1000);  // 1 second delay
+
     show_all_children();
 }
 

--- a/keela-exe/mainwindow.cpp
+++ b/keela-exe/mainwindow.cpp
@@ -90,14 +90,11 @@ MainWindow::MainWindow(): Gtk::Window() {
     on_camera_spin_changed();
     gst_element_set_state(GST_ELEMENT(pipeline), GST_STATE_PLAYING);
 
-    // @todo: implement a callback to update the gain range after the camera is ready
-    //        this is just to get help get started for now
-    Glib::signal_timeout().connect_once([this]() {
-        for (const auto &camera : cameras) {
-            camera->update_gain_range();
-            camera->update_exposure_time_range();
-        }
-    }, 1000);  // 1 second delay
+    // Query hardware capabilities to set ranges in the UI
+    for (const auto &camera : cameras) {
+        camera->update_gain_range();
+        camera->update_exposure_time_range();
+    }
 
     show_all_children();
 }

--- a/keela-widgets/CMakeLists.txt
+++ b/keela-widgets/CMakeLists.txt
@@ -40,5 +40,5 @@ add_library(keela-widgets labeledspinbutton.cpp keela-widgets/labeledspinbutton.
         keela-widgets/cameratrace.h
         cameratrace.cpp)
 add_dependencies(keela-widgets shader_resources)
-target_link_libraries(keela-widgets PUBLIC keela-pipeline PkgConfig::GTKMM PkgConfig::GIO PkgConfig::SPDLOG vendor-glad)
+target_link_libraries(keela-widgets PUBLIC keela-pipeline PkgConfig::GTKMM PkgConfig::GIO PkgConfig::SPDLOG PkgConfig::ARAVIS vendor-glad)
 target_include_directories(keela-widgets PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/keela-widgets/keela-widgets/cameramanager.h
+++ b/keela-widgets/keela-widgets/cameramanager.h
@@ -23,6 +23,11 @@
 #define ODD_FRAME 1
 
 namespace Keela {
+    // Structure to pass both parity and counter to frame probe callback
+    struct FrameProbeData {
+        int parity;
+        guint64* counter;
+    };
     class CameraManager final : public Keela::Bin {
     public:
         explicit CameraManager(guint id, std::string pix_fmt, bool split_streams);
@@ -67,6 +72,13 @@ namespace Keela {
     private:
         gulong even_frame_probe_id = 0;
         gulong odd_frame_probe_id = 0;
+
+        // Per-camera frame counter for sources that don't set buffer offset
+        guint64 manual_frame_counter = 0;
+        
+        // Data structures for frame probes
+        FrameProbeData even_probe_data{EVEN_FRAME, &manual_frame_counter};
+        FrameProbeData odd_probe_data{ODD_FRAME, &manual_frame_counter};
 
         void set_up_frame_splitting();
 

--- a/keela-widgets/keela-widgets/cameramanager.h
+++ b/keela-widgets/keela-widgets/cameramanager.h
@@ -36,6 +36,11 @@ namespace Keela {
 
         void set_experiment_directory(const std::string &path);
 
+        void set_gain(double gain);
+
+        // Query hardware capabilities
+        std::pair<double, double> get_gain_range() const;
+
         void start_recording();
 
         void stop_recording();
@@ -49,7 +54,7 @@ namespace Keela {
         std::shared_ptr<CameraStreamBin> camera_stream_even = std::make_shared<CameraStreamBin>("camera_stream_even");
         std::shared_ptr<CameraStreamBin> camera_stream_odd = std::make_shared<CameraStreamBin>("camera_stream_odd");
 
-        SimpleElement camera = SimpleElement("videotestsrc");
+        SimpleElement camera;
         SimpleElement caps_filter = SimpleElement("capsfilter");
         TransformBin transform = TransformBin("transform");
 
@@ -103,6 +108,8 @@ namespace Keela {
         static std::string get_filename(std::string directory, guint cam_id, std::string suffix = "");
 
         void add_odd_camera_stream();
+
+        bool is_aravis_src() const;
     };
 }  // namespace Keela
 #endif  // CAMERAMANAGER_H

--- a/keela-widgets/keela-widgets/cameramanager.h
+++ b/keela-widgets/keela-widgets/cameramanager.h
@@ -12,6 +12,7 @@
 #include <keela-pipeline/simpleelement.h>
 #include <keela-pipeline/snapshotbin.h>
 #include <keela-pipeline/transformbin.h>
+#include <arv.h>
 
 #include <atomic>
 #include <set>
@@ -36,10 +37,16 @@ namespace Keela {
 
         void set_experiment_directory(const std::string &path);
 
-        void set_gain(double gain);
-
         // Query hardware capabilities
         std::pair<double, double> get_gain_range() const;
+
+        std::pair<double, double> get_exposure_time_range() const;
+
+        // Control hardware settings
+        void set_gain(double gain);
+
+        void set_exposure(double exposure);
+
 
         void start_recording();
 
@@ -109,7 +116,9 @@ namespace Keela {
 
         void add_odd_camera_stream();
 
-        bool is_aravis_src() const;
+        ArvCamera* get_aravis_camera() const;
+
+        ArvCamera* aravis_camera = nullptr;
     };
 }  // namespace Keela
 #endif  // CAMERAMANAGER_H

--- a/keela-widgets/keela-widgets/cameramanager.h
+++ b/keela-widgets/keela-widgets/cameramanager.h
@@ -4,6 +4,7 @@
 
 #ifndef CAMERAMANAGER_H
 #define CAMERAMANAGER_H
+#include <arv.h>
 #include <keela-pipeline/CameraStreamBin.h>
 #include <keela-pipeline/bin.h>
 #include <keela-pipeline/caps.h>
@@ -12,7 +13,6 @@
 #include <keela-pipeline/simpleelement.h>
 #include <keela-pipeline/snapshotbin.h>
 #include <keela-pipeline/transformbin.h>
-#include <arv.h>
 
 #include <atomic>
 #include <set>
@@ -45,8 +45,7 @@ namespace Keela {
         // Control hardware settings
         void set_gain(double gain);
 
-        void set_exposure(double exposure);
-
+        void set_exposure_time(double exposure);
 
         void start_recording();
 
@@ -116,9 +115,9 @@ namespace Keela {
 
         void add_odd_camera_stream();
 
-        ArvCamera* get_aravis_camera() const;
+        ArvCamera *get_aravis_camera() const;
 
-        ArvCamera* aravis_camera = nullptr;
+        ArvCamera *aravis_camera = nullptr;
     };
 }  // namespace Keela
 #endif  // CAMERAMANAGER_H

--- a/keela-widgets/keela-widgets/plugin_utils.h
+++ b/keela-widgets/keela-widgets/plugin_utils.h
@@ -5,6 +5,7 @@
 #ifndef KEELA_PLUGIN_UTILS_H
 #define KEELA_PLUGIN_UTILS_H
 
+#include <aravis-0.8/arv.h>
 #include <gstreamer-1.0/gst/gst.h>
 
 #include <string>
@@ -16,10 +17,21 @@ namespace Keela {
     bool is_custom_videotestsrc_available();
 
     /**
-     * Get the appropriate video test source element name
-     * Returns "keelavideotestsrc" if available, otherwise "videotestsrc"
+     * Check if aravissrc plugin is available (plugin only, not camera)
      */
-    std::string get_video_test_source_name();
+    bool is_aravissrc_plugin_available();
+
+
+    /**
+     * Test and report camera detection status
+     */
+    bool aravis_camera_connected();
+
+    /**
+     * Get the appropriate video source element name.
+     * Preference order: aravissrc (with camera) > keelavideotestsrc > videotestsrc
+     */
+    std::string get_video_source_name();
 }  // namespace Keela
 
 #endif  // KEELA_PLUGIN_UTILS_H

--- a/keela-widgets/plugin_utils.cpp
+++ b/keela-widgets/plugin_utils.cpp
@@ -4,6 +4,7 @@
 
 #include "keela-widgets/plugin_utils.h"
 
+#include <aravis-0.8/arv.h>
 #include <spdlog/spdlog.h>
 
 namespace Keela {
@@ -17,7 +18,38 @@ namespace Keela {
         return false;
     }
 
-    std::string get_video_test_source_name() {
+    bool is_aravissrc_plugin_available() {
+        GstElementFactory* factory = gst_element_factory_find("aravissrc");
+        if (factory) {
+            gst_object_unref(factory);
+            return true;
+        }
+        return false;
+    }
+
+    bool is_aravis_camera_available() {
+        // then check to see if any cameras are connected
+        arv_update_device_list();
+        unsigned int n_devices = arv_get_n_devices();
+
+        if (n_devices > 0) {
+            spdlog::info("Aravis cameras detected: {}", n_devices);
+            // list all camera ids:
+            for (unsigned int i = 0; i < n_devices; i++) {
+                spdlog::info("  Camera {}: {}", i, arv_get_device_id(i));
+            }
+            return true;
+        } else {
+            spdlog::debug("No Aravis cameras detected");
+            return false;
+        }
+    }
+
+    std::string get_video_source_name() {
+        if (aravis_camera_connected()) {
+            spdlog::info("Using aravissrc plugin");
+            return "aravissrc";
+        }
 #ifdef KEELA_VIDEOTESTSRC_ENABLED
         if (is_custom_videotestsrc_available()) {
             spdlog::info("Using custom keelavideotestsrc plugin");
@@ -30,5 +62,26 @@ namespace Keela {
         spdlog::info("Custom videotestsrc disabled at build time - using standard videotestsrc plugin");
         return "videotestsrc";
 #endif
+    }
+
+    bool aravis_camera_connected() {
+        spdlog::info("=== Camera Detection Status ===");
+
+        bool plugin_available = is_aravissrc_plugin_available();
+        bool camera_available = is_aravis_camera_available();
+
+        spdlog::info("Aravis plugin available: {}", plugin_available ? "YES" : "NO");
+        spdlog::info("Aravis camera connected: {}", camera_available ? "YES" : "NO");
+
+        if (plugin_available && !camera_available) {
+            spdlog::warn("Aravis plugin found but no camera detected - check camera connection");
+            return false;
+        } else if (!plugin_available) {
+            spdlog::warn("Aravis plugin not found - check if aravis is installed");
+            return false;
+        }
+
+        spdlog::info("================================");
+        return true;
     }
 }  // namespace Keela


### PR DESCRIPTION
* adds support for adding Aravis based cameras as an `aravissrc`
  * the CameraManager will pick a video video source with teh following priority: 
    1. aravissrc (if a camera is connected) 
    2. keelavideotestsrc (if -DENABLE_KEELA_VIDEOTESTSRC=ON flag is set 
    3. videotestsrc
* Queries the camera hardware with the Aravis library to find the bounds of gain and exposure. It uses these bounds to limit the appropriate spins in the UI
* Supports setting gain and expose with Aravis sdk and confirms the settings have been applied correctly.
* Adds a manual frame counter to `user_data` in the frame splitting probe, as the `aravissrc` has an uninitialized `buffer_offset`. Originally we were using a static variable here, but Brandon pointed out that this would be a big problem for multiple cameras!


