### PR TITLE
Giant traces to fill entire available area

### DIFF
--- a/keela-exe/mainwindow.cpp
+++ b/keela-exe/mainwindow.cpp
@@ -89,7 +89,7 @@ MainWindow::MainWindow() : Gtk::Window() {
 	trace_control_row_box.pack_start(trace_clear_buffer_button);
 
 	container.add(show_trace_check);
-	container.pack_start(trace_control_row_box);
+	container.pack_start(trace_control_row_box, false, false, 0);
 
 	restart_camera_button.signal_clicked().connect(sigc::mem_fun(this, &MainWindow::reset_cameras));
 	restart_camera_button.set_label("Restart Camera(s)");

--- a/keela-exe/tracewindow.cpp
+++ b/keela-exe/tracewindow.cpp
@@ -31,8 +31,8 @@ void Keela::TraceWindow::addTraces(const std::vector<std::shared_ptr<Keela::ITra
 		traces.push_back(widget);
 		row_box->pack_start(*widget, true, true, 0);
 	}
-
-	container.pack_start(*row_box, false, false, 10);
+	// Expand so traces take up all available space
+	container.pack_start(*row_box, true, true, 10);
 	show_all_children();
 	spdlog::info("TraceWindow::{}: Added {} traces in a row", __func__, traces_to_add.size());
 }

--- a/keela-widgets/GLTraceRender.cpp
+++ b/keela-widgets/GLTraceRender.cpp
@@ -25,7 +25,9 @@ Keela::GLTraceRender::GLTraceRender(const std::shared_ptr<ITraceable> &cam_to_tr
 	hbox->pack_end(min_label);
 	hbox->pack_end(max_label);
 	Container::add(gl_area);
-	gl_area.set_size_request(300, 128);
+	// Expand so traces take up all available space
+	gl_area.set_vexpand(true);
+	gl_area.set_hexpand(true);
 	trace = cam_to_trace;
 
 	spdlog::debug("{}: Loading vertex shader resource", __func__);


### PR DESCRIPTION
Lil' PR to have the traces fill up all of their available space.


https://github.com/user-attachments/assets/9b9cf9c1-7c4f-40b5-896b-cf466e0c148e



Found a new bug while recording this where increasing the number of cameras always adds 2, but decreasing decrements 1 as expected. Will look into this later this week!