### PR TITLE
Add ability to invert traces

### DIFF
--- a/keela-widgets/GLTraceRender.cpp
+++ b/keela-widgets/GLTraceRender.cpp
@@ -18,12 +18,18 @@
 Keela::GLTraceRender::GLTraceRender(const std::shared_ptr<ITraceable> &cam_to_trace)
     : Gtk::Box(Gtk::ORIENTATION_VERTICAL) {
 	spdlog::info(__func__);
+
 	name_label.set_text(cam_to_trace->get_name());
 	auto hbox = Gtk::make_managed<Gtk::Box>(Gtk::ORIENTATION_HORIZONTAL);
 	Container::add(*hbox);
+
 	hbox->add(name_label);
 	hbox->pack_end(min_label);
 	hbox->pack_end(max_label);
+
+	invert_y_axis_check.set_label("Invert Y Axis");
+	hbox->pack_end(invert_y_axis_check);
+
 	Container::add(gl_area);
 	// Expand so traces take up all available space
 	gl_area.set_vexpand(true);
@@ -208,6 +214,8 @@ bool Keela::GLTraceRender::on_gl_render(const Glib::RefPtr<Gdk::GLContext> &cont
 	loc = glGetUniformLocation(shader_program, "xoffset");
 	auto xoffset = plot_length - plot_points.size();
 	glUniform1f(loc, static_cast<float>(xoffset));
+	loc = glGetUniformLocation(shader_program, "invertY");
+	glUniform1i(loc, invert_y_axis_check.get_active());
 
 	glBufferData(GL_ARRAY_BUFFER, static_cast<long long>(plot_points.size() * sizeof(float)), plot_points_vec.data(),
 	             GL_DYNAMIC_DRAW);

--- a/keela-widgets/keela-widgets/GLTraceRender.h
+++ b/keela-widgets/keela-widgets/GLTraceRender.h
@@ -30,7 +30,7 @@ class ITraceable {
 
 class GLTraceRender final : public Gtk::Box {
    public:
-	explicit GLTraceRender(const std::shared_ptr<ITraceable>& cam_to_trace);
+	explicit GLTraceRender(const std::shared_ptr<ITraceable> &cam_to_trace);
 
 	~GLTraceRender() override;
 
@@ -47,6 +47,9 @@ class GLTraceRender final : public Gtk::Box {
 	Gtk::Label name_label;
 	Gtk::Label min_label;
 	Gtk::Label max_label;
+	// Some experiments use fluorescence that is stronger at lower values
+	// this checkbox allows inverting the y axis for better visualization of the "real" signal
+	Gtk::CheckButton invert_y_axis_check;
 
 	// *basically* a pointer to the camera control window
 	std::shared_ptr<Keela::ITraceable> trace;
@@ -55,7 +58,7 @@ class GLTraceRender final : public Gtk::Box {
 
 	void on_gl_realize();
 
-	bool on_gl_render(const Glib::RefPtr<Gdk::GLContext>& context);
+	bool on_gl_render(const Glib::RefPtr<Gdk::GLContext> &context);
 
 	unsigned int VAO = -1;
 	unsigned int VBO = -1;
@@ -80,10 +83,10 @@ class GLTraceRender final : public Gtk::Box {
 	 * function to be used in worker_thread in order to process video data
 	 * @param token
 	 */
-	void process_video_data(const std::stop_token& token);
+	void process_video_data(const std::stop_token &token);
 
 	template <typename T>
-	double calculate_roi_average(GstSample* sample, GstStructure* structure, std::endian endianness);
+	double calculate_roi_average(GstSample *sample, GstStructure *structure, std::endian endianness);
 };
 }  // namespace Keela
 #endif  // GLTRACERENDER_H

--- a/keela-widgets/shaders/trace-vertex.glsl
+++ b/keela-widgets/shaders/trace-vertex.glsl
@@ -5,6 +5,7 @@ A point to plot in non-clip coordinates
 */
 layout (location = 0) in float y;
 uniform uint numSamples;
+uniform bool invertY = false;
 
 uniform float sampleMax = 255;
 uniform float sampleMin = 0;
@@ -29,4 +30,8 @@ void main() {
     // offset is applied to every y coord such that sampleMin will be transformed to 0.0
     yoffset = min >= 0 ? min : -min;
     gl_Position = vec4(((x + xoffset) * 2 / numSamples) - 1, 2 * scale * (y - yoffset) - 1, 0.0, 1.0);
+    
+    if (invertY) {
+        gl_Position.y = -gl_Position.y;
+    }
 }


### PR DESCRIPTION
This PR adds the ability to invert the trace plot. 
Some experiments use fluorescent dyes that react more strongly at lower values. This lets us better visualize the "real" signal.

https://github.com/user-attachments/assets/387a04fb-4681-4b41-a7fc-210f591220b5

^love the encoding artifacts on this demo video!