### PR TITLE
basic cpack config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,10 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.28)
 project(Keela)
 find_package(PkgConfig)
 
+include(KeelaCPackConfig.cmake)
 include(CPack)
+
+install(FILES "LICENSE" DESTINATION ./)
 # GoogleTest requires at least C++17
 # We need C++20 for jthreads
 # need c++23 for std::byteswap
@@ -38,9 +41,9 @@ add_subdirectory(vendor)
 add_subdirectory(keela-widgets)
 add_subdirectory(keela-pipeline)
 add_subdirectory(keela-exe)
-if(ENABLE_TEST)
-add_subdirectory(keela-test)
-endif()
+if (ENABLE_TEST)
+    add_subdirectory(keela-test)
+endif ()
 add_subdirectory(reference)
 
 # Add a target to clean configuration when switching video test source modes

--- a/KeelaCPackConfig.cmake
+++ b/KeelaCPackConfig.cmake
@@ -1,0 +1,22 @@
+set(CPACK_THREADS 0)
+# show project license upon installation
+set(CPACK_RESOURCE_FILE_LICENSE
+        "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE")
+
+# set up desktop links upon installation
+set(CPACK_PACKAGE_EXECUTABLES "keela" "Keela")
+set(CPACK_CREATE_DESKTOP_LINKS "keela")
+
+# window-dressing stuff
+set(CPACK_PACKAGE_VENDOR "Georgia Institute of Technology")
+set(KEELA_RESOURCE_DIR "${PROJECT_SOURCE_DIR}/resources")
+set(KEELA_ICON_FILE "${KEELA_RESOURCE_DIR}/KeelaIcon.ico")
+
+#set(CPACK_CREATE_DESKTOP_LINKS keela)
+# BEGIN NSIS specific configuration
+
+set(CPACK_NSIS_MUI_ICON ${KEELA_ICON_FILE})
+set(CPACK_NSIS_MUI_UNIICON ${KEELA_ICON_FILE})
+
+#set(CPACK_NSIS_MODIFY_PATH ON)
+# END NSIS configuration

--- a/keela-exe/CMakeLists.txt
+++ b/keela-exe/CMakeLists.txt
@@ -7,11 +7,14 @@ add_executable(keela main.cpp mainwindow.cpp mainwindow.h
 
 target_link_libraries(keela PRIVATE keela-widgets keela-pipeline PkgConfig::GSTREAMER PkgConfig::GTKMM PkgConfig::SPDLOG)
 
-install(TARGETS keela 
-    RUNTIME_DEPENDENCIES
-    PRE_EXCLUDE_REGEXES "api-ms-" "ext-ms-"
-    POST_EXCLUDE_REGEXES ".*system32/.*\\.dll"
-    DIRECTORIES 
+install(TARGETS keela
+        RUNTIME_DEPENDENCIES
+        PRE_EXCLUDE_REGEXES "api-ms-" "ext-ms-"
+        POST_EXCLUDE_REGEXES ".*system32/.*\\.dll"
+        DIRECTORIES
         "$ENV{MINGW_PREFIX}/bin"
-        "C:/msys64/mingw64/bin" 
+        "C:/msys64/mingw64/bin"
 )
+
+#C:\msys64\mingw64\lib\gstreamer-1.0
+install(DIRECTORY "C:/msys64/mingw64/lib/gstreamer-1.0/" DESTINATION bin/plugins)

--- a/keela-videotestsrc/CMakeLists.txt
+++ b/keela-videotestsrc/CMakeLists.txt
@@ -26,7 +26,7 @@ target_compile_definitions(gstkeelavideotestsrc PRIVATE
 # Set plugin installation directory
 set(PLUGIN_INSTALL_DIR ${CMAKE_BINARY_DIR}/plugins)
 install(TARGETS gstkeelavideotestsrc
-        LIBRARY DESTINATION ${PLUGIN_INSTALL_DIR}
+        LIBRARY DESTINATION bin/plugins # DESTINATION is a relative path
 )
 
 # Copy plugin to installation directory after build


### PR DESCRIPTION
Add CPack to our build configuration in order to automatically generate platform specific installer programs