### PR TITLE
Factor stream splitting outside of CameraManager

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ endif ()
 if (USE_HSLUV)
     add_compile_definitions(KEELA_USE_HSLUV)
 endif ()
-
+enable_testing()
 add_subdirectory(vendor)
 add_subdirectory(keela-widgets)
 add_subdirectory(keela-pipeline)

--- a/keela-exe/cameracontrolwindow.cpp
+++ b/keela-exe/cameracontrolwindow.cpp
@@ -81,11 +81,6 @@ Keela::CameraControlWindow::CameraControlWindow(const guint id, std::string pix_
 
 	set_vexpand(false);
 
-	/*
-	if(camera_manager->is_frame_splitting_enabled()) {
-	    add_split_frame_ui();
-	}*/
-
 	h_container.pack_start(video_hbox, false, false, 10);
 
 	auto gl_bin = Gtk::make_managed<Gtk::Box>(Gtk::ORIENTATION_VERTICAL);
@@ -260,20 +255,6 @@ void Keela::CameraControlWindow::update_traces() {
 	if(camera_manager->is_frame_splitting_enabled()) {
 		even_name += " (Even)";
 	}
-	// TODO: return a vec of CameraStreamBins from CameraManager and create a trace for each
-	// TODO TODO: uncomment this
-	// auto even_trace = std::make_shared<CameraTrace>(camera_manager->camera_stream_even->get_trace_bin(),
-	//                                                trace_gizmo_even, *video_presentation_even, even_name);
-	// m_traces.push_back(even_trace);
-
-	// Add odd trace if frame splitting is enabled
-	// TODO: uncomment this
-	// if(camera_manager->is_frame_splitting_enabled() && trace_gizmo_odd) {
-	// auto odd_trace =
-	//     std::make_shared<CameraTrace>(camera_manager->camera_stream_odd->get_trace_bin(), trace_gizmo_odd,
-	//                                   *video_presentation_odd, "Camera " + std::to_string(id) + " (Odd)");
-	// m_traces.push_back(odd_trace);
-	//}
 }
 
 void Keela::CameraControlWindow::set_trace_bin_framerate_caps(guint fps) {

--- a/keela-exe/cameracontrolwindow.cpp
+++ b/keela-exe/cameracontrolwindow.cpp
@@ -74,11 +74,10 @@ Keela::CameraControlWindow::CameraControlWindow(const guint id, std::string pix_
 	flip_vert_check.signal_toggled().connect(sigc::mem_fun(*this, &CameraControlWindow::on_flip_vert_changed));
 	v_container.add(flip_vert_check);
 
-	// TODO: dynamically cast camera_manager->presentation to a WidgetElement to
-	// get a handle to a widget to add to the window
-	fetch_image_button.signal_clicked().connect(
-	    sigc::mem_fun(*camera_manager->camera_stream_even->snapshot, &Keela::SnapshotBin::take_snapshot));
-	v_container.add(fetch_image_button);
+	// fetch_image_button.signal_clicked().connect(
+	//     sigc::mem_fun(*camera_manager->camera_stream_even->snapshot, &Keela::SnapshotBin::take_snapshot));
+	// TODO: this serves as a reminder to properly resolve where the snapshotbin is
+	// v_container.add(fetch_image_button);
 
 	set_vexpand(false);
 
@@ -86,10 +85,11 @@ Keela::CameraControlWindow::CameraControlWindow(const guint id, std::string pix_
 	trace_gizmo_even = std::make_shared<TraceGizmo>();
 
 	// Set up video presentations, video_presentation_even renders all frames unless split is enabled
-	video_presentation_even = std::make_unique<VideoPresentation>(
-	    "Camera " + std::to_string(id), camera_manager->camera_stream_even->presentation, *this);
-	video_presentation_even->add_overlay_widget(*trace_gizmo_even);
-	video_hbox.pack_start(*video_presentation_even, false, false, 10);
+	// TODO: uncomment this
+	// video_presentation_even = std::make_unique<VideoPresentation>(
+	//    "Camera " + std::to_string(id), camera_manager->camera_stream_even->presentation, *this);
+	// video_presentation_even->add_overlay_widget(*trace_gizmo_even);
+	// video_hbox.pack_start(*video_presentation_even, false, false, 10);
 
 	if(camera_manager->is_frame_splitting_enabled()) {
 		add_split_frame_ui();
@@ -249,17 +249,19 @@ void Keela::CameraControlWindow::update_traces() {
 	if(camera_manager->is_frame_splitting_enabled()) {
 		even_name += " (Even)";
 	}
-
-	auto even_trace = std::make_shared<CameraTrace>(camera_manager->camera_stream_even->get_trace_bin(),
-	                                                trace_gizmo_even, *video_presentation_even, even_name);
-	m_traces.push_back(even_trace);
+	// TODO: return a vec of CameraStreamBins from CameraManager and create a trace for each
+	// TODO TODO: uncomment this
+	// auto even_trace = std::make_shared<CameraTrace>(camera_manager->camera_stream_even->get_trace_bin(),
+	//                                                trace_gizmo_even, *video_presentation_even, even_name);
+	// m_traces.push_back(even_trace);
 
 	// Add odd trace if frame splitting is enabled
+	// TODO: uncomment this
 	if(camera_manager->is_frame_splitting_enabled() && trace_gizmo_odd) {
-		auto odd_trace =
-		    std::make_shared<CameraTrace>(camera_manager->camera_stream_odd->get_trace_bin(), trace_gizmo_odd,
-		                                  *video_presentation_odd, "Camera " + std::to_string(id) + " (Odd)");
-		m_traces.push_back(odd_trace);
+		// auto odd_trace =
+		//     std::make_shared<CameraTrace>(camera_manager->camera_stream_odd->get_trace_bin(), trace_gizmo_odd,
+		//                                   *video_presentation_odd, "Camera " + std::to_string(id) + " (Odd)");
+		// m_traces.push_back(odd_trace);
 	}
 }
 
@@ -274,24 +276,26 @@ void Keela::CameraControlWindow::set_trace_bin_framerate_caps(guint fps) {
 }
 
 void Keela::CameraControlWindow::add_split_frame_ui() {
+	/*
 	if(video_presentation_odd)
-		return;  // Already added
+	    return;  // Already added
 
 	// Create trace gizmo for odd frames
 	trace_gizmo_odd = std::make_shared<TraceGizmo>();
 
 	const auto rotation = rotation_combo.m_combo.get_active_id();
-	video_presentation_odd =
-	    std::make_unique<VideoPresentation>("Odd Frames", camera_manager->camera_stream_odd->presentation, *this,
-	                                        DEFAULT_PRESENTATION_WIDTH, DEFAULT_PRESENTATION_HEIGHT);
+	// TODO: uncomment this
+	// video_presentation_odd =
+	//    std::make_unique<VideoPresentation>("Odd Frames", camera_manager->camera_stream_odd->presentation, *this,
+	//                                        DEFAULT_PRESENTATION_WIDTH, DEFAULT_PRESENTATION_HEIGHT);
 	if(rotation == ROTATION_90 || rotation == ROTATION_270) {
-		video_presentation_odd->swap_dimensions();
+	    video_presentation_odd->swap_dimensions();
 	}
 
 	video_presentation_odd->add_overlay_widget(*trace_gizmo_odd);
 	video_hbox.pack_start(*video_presentation_odd, false, false, 10);
 
-	show_all_children();
+	show_all_children();*/
 }
 
 void Keela::CameraControlWindow::remove_split_frame_ui() {

--- a/keela-exe/cameracontrolwindow.cpp
+++ b/keela-exe/cameracontrolwindow.cpp
@@ -74,10 +74,9 @@ Keela::CameraControlWindow::CameraControlWindow(const guint id, std::string pix_
 	flip_vert_check.signal_toggled().connect(sigc::mem_fun(*this, &CameraControlWindow::on_flip_vert_changed));
 	v_container.add(flip_vert_check);
 
-	// fetch_image_button.signal_clicked().connect(
-	//     sigc::mem_fun(*camera_manager->camera_stream_even->snapshot, &Keela::SnapshotBin::take_snapshot));
-	// TODO: this serves as a reminder to properly resolve where the snapshotbin is
-	// v_container.add(fetch_image_button);
+	fetch_image_button.signal_clicked().connect(
+	    sigc::mem_fun(camera_manager->snapshot, &Keela::SnapshotBin::take_snapshot));
+	v_container.add(fetch_image_button);
 
 	set_vexpand(false);
 
@@ -189,18 +188,8 @@ void Keela::CameraControlWindow::on_flip_vert_changed() const {
 
 void Keela::CameraControlWindow::update_split_frame_state(bool should_split_frames) {
 	camera_manager->set_frame_splitting(should_split_frames);
-	if(should_split_frames) {
-		spdlog::info("Adding split frame UI");
-		// add_split_frame_ui();
-	} else {
-		spdlog::info("Removing split frame UI");
-		// remove_split_frame_ui();
-	}
-	// Update traces whenever split frame state changes
-
 	setup_stream_ui();
-	// TODO: traces broken for now. uncomment when fixed
-	// update_traces();
+	update_traces();
 }
 
 bool Keela::CameraControlWindow::is_heatmap_enabled() {
@@ -217,17 +206,21 @@ float Keela::CameraControlWindow::heatmap_max() {
 void Keela::CameraControlWindow::setup_stream_ui() {
 	auto streams = camera_manager->get_streams();
 	auto n_streams = streams.size();
-	trace_gizmos.clear();
 	presentation_widgets.clear();
 
 	for(size_t i = 0; i < n_streams; i++) {
-		auto gizmo = std::make_shared<TraceGizmo>();
+		std::shared_ptr<TraceGizmo> gizmo;
+		if(i < trace_gizmos.size()) {
+			gizmo = trace_gizmos[i];
+		} else {
+			gizmo = std::make_shared<TraceGizmo>();
+			trace_gizmos.push_back(gizmo);
+		}
 		auto stream = streams[i];
 		std::string label = "Stream " + std::to_string(i);
 		auto presentation = std::make_shared<VideoPresentation>(label, stream->presentation, *this);
 		presentation->add_overlay_widget(*gizmo);
 		presentation_widgets.push_back(presentation);
-		trace_gizmos.push_back(gizmo);
 		video_hbox.pack_start(*presentation, false, false, 10);
 	}
 	show_all_children();
@@ -250,10 +243,15 @@ std::vector<std::shared_ptr<Keela::ITraceable>> Keela::CameraControlWindow::get_
 void Keela::CameraControlWindow::update_traces() {
 	m_traces.clear();
 
-	// Always add the even trace
-	std::string even_name = "Camera " + std::to_string(id);
-	if(camera_manager->is_frame_splitting_enabled()) {
-		even_name += " (Even)";
+	auto streams = camera_manager->get_streams();
+
+	for(size_t i = 0; i < streams.size(); i++) {
+		auto gizmo = trace_gizmos[i];
+		auto stream = streams[i];
+		auto presentation = presentation_widgets[i];
+		std::string name = "Stream " + std::to_string(i);
+		auto trace = std::make_shared<CameraTrace>(stream->get_trace_bin(), gizmo, *presentation, name);
+		m_traces.push_back(trace);
 	}
 }
 

--- a/keela-exe/cameracontrolwindow.cpp
+++ b/keela-exe/cameracontrolwindow.cpp
@@ -81,19 +81,10 @@ Keela::CameraControlWindow::CameraControlWindow(const guint id, std::string pix_
 
 	set_vexpand(false);
 
-	// Create overlay for trace gizmo
-	trace_gizmo_even = std::make_shared<TraceGizmo>();
-
-	// Set up video presentations, video_presentation_even renders all frames unless split is enabled
-	// TODO: uncomment this
-	// video_presentation_even = std::make_unique<VideoPresentation>(
-	//    "Camera " + std::to_string(id), camera_manager->camera_stream_even->presentation, *this);
-	// video_presentation_even->add_overlay_widget(*trace_gizmo_even);
-	// video_hbox.pack_start(*video_presentation_even, false, false, 10);
-
+	/*
 	if(camera_manager->is_frame_splitting_enabled()) {
-		add_split_frame_ui();
-	}
+	    add_split_frame_ui();
+	}*/
 
 	h_container.pack_start(video_hbox, false, false, 10);
 
@@ -108,6 +99,7 @@ Keela::CameraControlWindow::CameraControlWindow(const guint id, std::string pix_
 		update_binning_modes();
 	}
 
+	setup_stream_ui();
 	show_all_children();
 	show();
 }
@@ -180,14 +172,12 @@ void Keela::CameraControlWindow::on_rotation_changed() {
 
 void Keela::CameraControlWindow::update_presentation_sizes(const std::string &rotation) {
 	if(rotation == ROTATION_90 || rotation == ROTATION_270) {
-		video_presentation_even->swap_dimensions();
-		if(video_presentation_odd) {
-			video_presentation_odd->swap_dimensions();
+		for(auto presentation : presentation_widgets) {
+			presentation->swap_dimensions();
 		}
 	} else {
-		video_presentation_even->reset_dimensions();
-		if(video_presentation_odd) {
-			video_presentation_odd->reset_dimensions();
+		for(auto presentation : presentation_widgets) {
+			presentation->reset_dimensions();
 		}
 	}
 }
@@ -206,13 +196,16 @@ void Keela::CameraControlWindow::update_split_frame_state(bool should_split_fram
 	camera_manager->set_frame_splitting(should_split_frames);
 	if(should_split_frames) {
 		spdlog::info("Adding split frame UI");
-		add_split_frame_ui();
+		// add_split_frame_ui();
 	} else {
 		spdlog::info("Removing split frame UI");
-		remove_split_frame_ui();
+		// remove_split_frame_ui();
 	}
 	// Update traces whenever split frame state changes
-	update_traces();
+
+	setup_stream_ui();
+	// TODO: traces broken for now. uncomment when fixed
+	// update_traces();
 }
 
 bool Keela::CameraControlWindow::is_heatmap_enabled() {
@@ -225,6 +218,24 @@ float Keela::CameraControlWindow::heatmap_min() {
 
 float Keela::CameraControlWindow::heatmap_max() {
 	return static_cast<float>(range_max_spin.m_spin.get_value()) / heatmap_scale;
+}
+void Keela::CameraControlWindow::setup_stream_ui() {
+	auto streams = camera_manager->get_streams();
+	auto n_streams = streams.size();
+	trace_gizmos.clear();
+	presentation_widgets.clear();
+
+	for(size_t i = 0; i < n_streams; i++) {
+		auto gizmo = std::make_shared<TraceGizmo>();
+		auto stream = streams[i];
+		std::string label = "Stream " + std::to_string(i);
+		auto presentation = std::make_shared<VideoPresentation>(label, stream->presentation, *this);
+		presentation->add_overlay_widget(*gizmo);
+		presentation_widgets.push_back(presentation);
+		trace_gizmos.push_back(gizmo);
+		video_hbox.pack_start(*presentation, false, false, 10);
+	}
+	show_all_children();
 }
 
 std::vector<std::shared_ptr<Keela::ITraceable>> Keela::CameraControlWindow::get_traces() {
@@ -257,12 +268,12 @@ void Keela::CameraControlWindow::update_traces() {
 
 	// Add odd trace if frame splitting is enabled
 	// TODO: uncomment this
-	if(camera_manager->is_frame_splitting_enabled() && trace_gizmo_odd) {
-		// auto odd_trace =
-		//     std::make_shared<CameraTrace>(camera_manager->camera_stream_odd->get_trace_bin(), trace_gizmo_odd,
-		//                                   *video_presentation_odd, "Camera " + std::to_string(id) + " (Odd)");
-		// m_traces.push_back(odd_trace);
-	}
+	// if(camera_manager->is_frame_splitting_enabled() && trace_gizmo_odd) {
+	// auto odd_trace =
+	//     std::make_shared<CameraTrace>(camera_manager->camera_stream_odd->get_trace_bin(), trace_gizmo_odd,
+	//                                   *video_presentation_odd, "Camera " + std::to_string(id) + " (Odd)");
+	// m_traces.push_back(odd_trace);
+	//}
 }
 
 void Keela::CameraControlWindow::set_trace_bin_framerate_caps(guint fps) {
@@ -272,36 +283,6 @@ void Keela::CameraControlWindow::set_trace_bin_framerate_caps(guint fps) {
 		if(trace_bin) {
 			trace_bin->set_trace_framerate(fps);
 		}
-	}
-}
-
-void Keela::CameraControlWindow::add_split_frame_ui() {
-	/*
-	if(video_presentation_odd)
-	    return;  // Already added
-
-	// Create trace gizmo for odd frames
-	trace_gizmo_odd = std::make_shared<TraceGizmo>();
-
-	const auto rotation = rotation_combo.m_combo.get_active_id();
-	// TODO: uncomment this
-	// video_presentation_odd =
-	//    std::make_unique<VideoPresentation>("Odd Frames", camera_manager->camera_stream_odd->presentation, *this,
-	//                                        DEFAULT_PRESENTATION_WIDTH, DEFAULT_PRESENTATION_HEIGHT);
-	if(rotation == ROTATION_90 || rotation == ROTATION_270) {
-	    video_presentation_odd->swap_dimensions();
-	}
-
-	video_presentation_odd->add_overlay_widget(*trace_gizmo_odd);
-	video_hbox.pack_start(*video_presentation_odd, false, false, 10);
-
-	show_all_children();*/
-}
-
-void Keela::CameraControlWindow::remove_split_frame_ui() {
-	if(video_presentation_odd) {
-		video_hbox.remove(*video_presentation_odd);
-		video_presentation_odd.reset();
 	}
 }
 

--- a/keela-exe/cameracontrolwindow.h
+++ b/keela-exe/cameracontrolwindow.h
@@ -51,12 +51,6 @@ class CameraControlWindow final : public Gtk::Window, public Keela::IControlGLCa
 	Gtk::CheckButton flip_vert_check = Gtk::CheckButton("Flip Along Vertical Center");
 	Gtk::Button fetch_image_button = Gtk::Button("Fetch Image");
 
-	// std::unique_ptr<VideoPresentation> video_presentation_even;
-	// std::unique_ptr<VideoPresentation> video_presentation_odd;
-
-	// std::shared_ptr<Keela::TraceGizmo> trace_gizmo_even;
-	// std::shared_ptr<Keela::TraceGizmo> trace_gizmo_odd;
-
 	guint id;
 
 	void on_range_check_toggled();

--- a/keela-exe/cameracontrolwindow.h
+++ b/keela-exe/cameracontrolwindow.h
@@ -51,11 +51,11 @@ class CameraControlWindow final : public Gtk::Window, public Keela::IControlGLCa
 	Gtk::CheckButton flip_vert_check = Gtk::CheckButton("Flip Along Vertical Center");
 	Gtk::Button fetch_image_button = Gtk::Button("Fetch Image");
 
-	std::unique_ptr<VideoPresentation> video_presentation_even;
-	std::unique_ptr<VideoPresentation> video_presentation_odd;
+	// std::unique_ptr<VideoPresentation> video_presentation_even;
+	// std::unique_ptr<VideoPresentation> video_presentation_odd;
 
-	std::shared_ptr<Keela::TraceGizmo> trace_gizmo_even;
-	std::shared_ptr<Keela::TraceGizmo> trace_gizmo_odd;
+	// std::shared_ptr<Keela::TraceGizmo> trace_gizmo_even;
+	// std::shared_ptr<Keela::TraceGizmo> trace_gizmo_odd;
 
 	guint id;
 
@@ -75,9 +75,9 @@ class CameraControlWindow final : public Gtk::Window, public Keela::IControlGLCa
 
 	void on_flip_vert_changed() const;
 
-	void add_split_frame_ui();
+	// void add_split_frame_ui();
 
-	void remove_split_frame_ui();
+	// void remove_split_frame_ui();
 
 	void update_traces();
 
@@ -111,6 +111,11 @@ class CameraControlWindow final : public Gtk::Window, public Keela::IControlGLCa
 	float heatmap_scale;
 
 	std::vector<std::shared_ptr<CameraTrace>> m_traces;
+
+	void setup_stream_ui();
+
+	std::vector<std::shared_ptr<VideoPresentation>> presentation_widgets;
+	std::vector<std::shared_ptr<TraceGizmo>> trace_gizmos;
 };
 }  // namespace Keela
 

--- a/keela-exe/cameracontrolwindow.h
+++ b/keela-exe/cameracontrolwindow.h
@@ -31,9 +31,6 @@ class CameraControlWindow final : public Gtk::Window, public Keela::IControlGLCa
 	Gtk::Box v_container = Gtk::Box(Gtk::ORIENTATION_VERTICAL);
 	Gtk::Box video_hbox = Gtk::Box(Gtk::ORIENTATION_HORIZONTAL);
 
-	std::unique_ptr<VideoPresentation> video_presentation_even;
-	std::unique_ptr<VideoPresentation> video_presentation_odd;
-
 	Gtk::CheckButton range_check = Gtk::CheckButton("Range");
 	Keela::LabeledSpinButton range_min_spin = Keela::LabeledSpinButton("Minimum");
 	Keela::LabeledSpinButton range_max_spin = Keela::LabeledSpinButton("Maximum");
@@ -53,6 +50,9 @@ class CameraControlWindow final : public Gtk::Window, public Keela::IControlGLCa
 	Gtk::CheckButton flip_horiz_check = Gtk::CheckButton("Flip Along Horizontal Center");
 	Gtk::CheckButton flip_vert_check = Gtk::CheckButton("Flip Along Vertical Center");
 	Gtk::Button fetch_image_button = Gtk::Button("Fetch Image");
+
+	std::unique_ptr<VideoPresentation> video_presentation_even;
+	std::unique_ptr<VideoPresentation> video_presentation_odd;
 
 	std::shared_ptr<Keela::TraceGizmo> trace_gizmo_even;
 	std::shared_ptr<Keela::TraceGizmo> trace_gizmo_odd;

--- a/keela-exe/cameracontrolwindow.h
+++ b/keela-exe/cameracontrolwindow.h
@@ -69,10 +69,6 @@ class CameraControlWindow final : public Gtk::Window, public Keela::IControlGLCa
 
 	void on_flip_vert_changed() const;
 
-	// void add_split_frame_ui();
-
-	// void remove_split_frame_ui();
-
 	void update_traces();
 
 	void update_presentation_sizes(const std::string &rotation);

--- a/keela-pipeline/CMakeLists.txt
+++ b/keela-pipeline/CMakeLists.txt
@@ -31,6 +31,8 @@ add_library(keela-pipeline presentationbin.cpp keela-pipeline/presentationbin.h
         keela-pipeline/consts.h
         CameraStreamBin.cpp
         keela-pipeline/CameraStreamBin.h
+        splitstreambin.cpp
+        keela-pipeline/splitstreambin.h
 )
 target_link_libraries(keela-pipeline PUBLIC PkgConfig::GSTREAMER PkgConfig::SPDLOG)
 

--- a/keela-pipeline/CameraStreamBin.cpp
+++ b/keela-pipeline/CameraStreamBin.cpp
@@ -17,10 +17,6 @@ Keela::CameraStreamBin::CameraStreamBin(const std::string &name) : QueueBin(name
 	CameraStreamBin::link();
 }
 
-Keela::CameraStreamBin::~CameraStreamBin() {
-	spdlog::debug(__func__);
-}
-
 void Keela::CameraStreamBin::link() {
 	spdlog::info("Linking CameraStreamBin {} internal structure", name);
 

--- a/keela-pipeline/CameraStreamBin.cpp
+++ b/keela-pipeline/CameraStreamBin.cpp
@@ -11,7 +11,6 @@
 Keela::CameraStreamBin::CameraStreamBin(const std::string &name) : QueueBin(name), name(name) {
 	spdlog::info("Creating CameraStreamBin: {}", name);
 	presentation = std::make_shared<PresentationBin>("presentation_" + this->name);
-	snapshot = std::make_shared<SnapshotBin>("snapshot_" + this->name);
 	trace = std::make_shared<TraceBin>("trace_" + this->name);
 
 	CameraStreamBin::link();
@@ -21,11 +20,10 @@ void Keela::CameraStreamBin::link() {
 	spdlog::info("Linking CameraStreamBin {} internal structure", name);
 
 	// Add internal tee and all child bins to this bin
-	add_elements(internal_tee, *presentation, *snapshot, *trace);
+	add_elements(internal_tee, *presentation, *trace);
 
 	// Link internal_tee -> all outputs
 	element_link_many(internal_tee, *presentation);
-	element_link_many(internal_tee, *snapshot);
 	element_link_many(internal_tee, *trace);
 	link_queue(internal_tee);
 }

--- a/keela-pipeline/keela-pipeline/CameraStreamBin.h
+++ b/keela-pipeline/keela-pipeline/CameraStreamBin.h
@@ -20,7 +20,7 @@ class CameraStreamBin final : public QueueBin, public EjectableElement {
 	SimpleElement internal_tee = SimpleElement("tee");
 
 	std::shared_ptr<PresentationBin> presentation;
-	std::shared_ptr<SnapshotBin> snapshot;
+	// std::shared_ptr<SnapshotBin> snapshot;
 	std::shared_ptr<TraceBin> trace;
 
 	std::shared_ptr<RecordBin> record_bin = nullptr;

--- a/keela-pipeline/keela-pipeline/CameraStreamBin.h
+++ b/keela-pipeline/keela-pipeline/CameraStreamBin.h
@@ -15,8 +15,7 @@ namespace Keela {
 class CameraStreamBin final : public QueueBin, public EjectableElement {
    public:
 	explicit CameraStreamBin(const std::string &name);
-
-	~CameraStreamBin() override;
+	~CameraStreamBin() override = default;
 
 	SimpleElement internal_tee = SimpleElement("tee");
 

--- a/keela-pipeline/keela-pipeline/EjectableElement.h
+++ b/keela-pipeline/keela-pipeline/EjectableElement.h
@@ -13,7 +13,7 @@ namespace Keela {
  *
  * This class is only suitable for elements which lie at the end of the pipeline and have no downstream elements.
  */
-class EjectableElement : virtual private Keela::Element {
+class EjectableElement : virtual public Keela::Element {
    public:
 	/**
 	 * Prepare the element for ejection from the pipeline, but do not wait for the element to finish processing
@@ -30,6 +30,17 @@ class EjectableElement : virtual private Keela::Element {
 	 * @param prepare true if the element should prepare itself for ejection, false if not
 	 */
 	void Eject(bool prepare);
+
+   protected:
+	/**
+	 * Retrieve the leaf elements of another leaf element. Use this method to chain multiple EjectableElements together
+	 *
+	 * normally an object can not access the protected or private methods of another object even if they derive from the
+	 * same type. This method allows us to circumvent this accessibility rule a bit
+	 */
+	static std::vector<Keela::Element *> GetLeaves(Keela::EjectableElement &other_element) {
+		return other_element.Leaves();
+	}
 
    private:
 	/**

--- a/keela-pipeline/keela-pipeline/bin.h
+++ b/keela-pipeline/keela-pipeline/bin.h
@@ -37,7 +37,7 @@ class Bin : public virtual Keela::Element {
 	 * @tparam First any type which can convert to GstElement*
 	 */
 	template <typename First, typename... Rest>
-	void add_elements(First first, Rest... rest) {
+	void add_elements(First &first, Rest &...rest) {
 		GstElement *e = first;
 
 		gst_object_ref(e);

--- a/keela-pipeline/keela-pipeline/bin.h
+++ b/keela-pipeline/keela-pipeline/bin.h
@@ -46,6 +46,10 @@ class Bin : public virtual Keela::Element {
 		if(!ret) {
 			throw std::runtime_error("Failed to add element to bin");
 		}
+		ret = gst_element_sync_state_with_parent(e);
+		if(!ret) {
+			throw std::runtime_error("Failed to sync state of element to bin");
+		}
 		add_elements(rest...);
 	}
 

--- a/keela-pipeline/keela-pipeline/splitstreambin.h
+++ b/keela-pipeline/keela-pipeline/splitstreambin.h
@@ -13,9 +13,10 @@ class SplitStreamBin final : public EjectableElement, public QueueBin {
 	SplitStreamBin();
 	~SplitStreamBin() override = default;
 
+	std::shared_ptr<Keela::CameraStreamBin> even_stream;
+	std::shared_ptr<Keela::CameraStreamBin> odd_stream;
+
    private:
-	Keela::CameraStreamBin even_stream;
-	Keela::CameraStreamBin odd_stream;
 	Keela::SimpleElement tee = SimpleElement("tee");
 	Keela::Element *Head() override;
 	std::vector<Keela::Element *> Leaves() override;

--- a/keela-pipeline/keela-pipeline/splitstreambin.h
+++ b/keela-pipeline/keela-pipeline/splitstreambin.h
@@ -1,0 +1,34 @@
+//
+// Created by brand on 12/26/2025.
+//
+
+#ifndef SPLITSTREAMBIN_H
+#define SPLITSTREAMBIN_H
+#include "CameraStreamBin.h"
+#include "EjectableElement.h"
+#include "queuebin.h"
+namespace Keela {
+class SplitStreamBin : public EjectableElement, public QueueBin {
+   public:
+	SplitStreamBin();
+	~SplitStreamBin() override = default;
+
+   private:
+	Keela::CameraStreamBin even_stream;
+	Keela::CameraStreamBin odd_stream;
+	Keela::SimpleElement tee = SimpleElement("tee");
+	Keela::Element *Head() override;
+	std::vector<Keela::Element *> Leaves() override;
+	void init() override;
+	void link() override;
+
+	struct FrameProbeData {
+		int parity;
+		guint64 *counter;
+	};
+
+	/// frame filtering callback
+	static GstPadProbeReturn frame_parity_probe_cb(GstPad *pad, GstPadProbeInfo *info, gpointer user_data);
+};
+}  // namespace Keela
+#endif  // SPLITSTREAMBIN_H

--- a/keela-pipeline/keela-pipeline/splitstreambin.h
+++ b/keela-pipeline/keela-pipeline/splitstreambin.h
@@ -8,7 +8,7 @@
 #include "EjectableElement.h"
 #include "queuebin.h"
 namespace Keela {
-class SplitStreamBin : public EjectableElement, public QueueBin {
+class SplitStreamBin final : public EjectableElement, public QueueBin {
    public:
 	SplitStreamBin();
 	~SplitStreamBin() override = default;
@@ -26,6 +26,13 @@ class SplitStreamBin : public EjectableElement, public QueueBin {
 		int parity;
 		guint64 *counter;
 	};
+
+	enum FrameParity { EVEN, ODD };
+
+	FrameProbeData even_probe_data = FrameProbeData(FrameParity::EVEN, &backup_counter);
+	FrameProbeData odd_probe_data = FrameProbeData(FrameParity::ODD, &backup_counter);
+
+	guint64 backup_counter = 0;
 
 	/// frame filtering callback
 	static GstPadProbeReturn frame_parity_probe_cb(GstPad *pad, GstPadProbeInfo *info, gpointer user_data);

--- a/keela-pipeline/keela-pipeline/utils.h
+++ b/keela-pipeline/keela-pipeline/utils.h
@@ -8,12 +8,12 @@
 
 namespace Keela {
 template <typename Last>
-inline void element_link_many(Last _) {
+inline void element_link_many(Last &_) {
 	spdlog::info("{} no more elements left to link", __func__);
 }
 
 template <typename First, typename Second, typename... Rest>
-inline void element_link_many(First first, Second second, Rest... rest) {
+inline void element_link_many(First &first, Second &second, Rest &...rest) {
 	GstElement *f = first;
 	GstElement *s = second;
 	auto fname = gst_element_get_name(f);

--- a/keela-pipeline/splitstreambin.cpp
+++ b/keela-pipeline/splitstreambin.cpp
@@ -7,6 +7,15 @@
 #include "keela-pipeline/utils.h"
 Keela::SplitStreamBin::SplitStreamBin() : even_stream("stream_even"), odd_stream("stream_odd") {
 }
+Keela::Element *Keela::SplitStreamBin::Head() {
+	return &tee;
+}
+std::vector<Keela::Element *> Keela::SplitStreamBin::Leaves() {
+	auto leaves = EjectableElement::GetLeaves(even_stream);
+	auto odd_leaves = EjectableElement::GetLeaves(odd_stream);
+	leaves.insert(leaves.end(), odd_leaves.begin(), odd_leaves.end());
+	return leaves;
+}
 void Keela::SplitStreamBin::init() {
 	add_elements(tee, even_stream, odd_stream);
 	GstPad *p;

--- a/keela-pipeline/splitstreambin.cpp
+++ b/keela-pipeline/splitstreambin.cpp
@@ -5,9 +5,11 @@
 #include "keela-pipeline/splitstreambin.h"
 
 #include "keela-pipeline/utils.h"
-Keela::SplitStreamBin::SplitStreamBin() {
+Keela::SplitStreamBin::SplitStreamBin() : QueueBin("SplitStreamBin") {
 	even_stream = std::make_shared<Keela::CameraStreamBin>("stream_even");
 	odd_stream = std::make_shared<Keela::CameraStreamBin>("stream_odd");
+	SplitStreamBin::init();
+	SplitStreamBin::link();
 }
 Keela::Element *Keela::SplitStreamBin::Head() {
 	return &tee;
@@ -36,7 +38,7 @@ void Keela::SplitStreamBin::init() {
 void Keela::SplitStreamBin::link() {
 	element_link_many(tee, *even_stream);
 	element_link_many(tee, *odd_stream);
-	link_queue(*even_stream);
+	link_queue(tee);
 }
 
 GstPadProbeReturn Keela::SplitStreamBin::frame_parity_probe_cb(GstPad *pad, GstPadProbeInfo *info, gpointer user_data) {

--- a/keela-pipeline/splitstreambin.cpp
+++ b/keela-pipeline/splitstreambin.cpp
@@ -12,7 +12,7 @@ Keela::SplitStreamBin::SplitStreamBin() : QueueBin("SplitStreamBin") {
 	SplitStreamBin::link();
 }
 Keela::Element *Keela::SplitStreamBin::Head() {
-	return &tee;
+	return &queue;
 }
 std::vector<Keela::Element *> Keela::SplitStreamBin::Leaves() {
 	auto leaves = EjectableElement::GetLeaves(*even_stream);

--- a/keela-pipeline/splitstreambin.cpp
+++ b/keela-pipeline/splitstreambin.cpp
@@ -5,36 +5,38 @@
 #include "keela-pipeline/splitstreambin.h"
 
 #include "keela-pipeline/utils.h"
-Keela::SplitStreamBin::SplitStreamBin() : even_stream("stream_even"), odd_stream("stream_odd") {
+Keela::SplitStreamBin::SplitStreamBin() {
+	even_stream = std::make_shared<Keela::CameraStreamBin>("stream_even");
+	odd_stream = std::make_shared<Keela::CameraStreamBin>("stream_odd");
 }
 Keela::Element *Keela::SplitStreamBin::Head() {
 	return &tee;
 }
 std::vector<Keela::Element *> Keela::SplitStreamBin::Leaves() {
-	auto leaves = EjectableElement::GetLeaves(even_stream);
-	auto odd_leaves = EjectableElement::GetLeaves(odd_stream);
+	auto leaves = EjectableElement::GetLeaves(*even_stream);
+	auto odd_leaves = EjectableElement::GetLeaves(*odd_stream);
 	leaves.insert(leaves.end(), odd_leaves.begin(), odd_leaves.end());
 	return leaves;
 }
 void Keela::SplitStreamBin::init() {
-	add_elements(tee, even_stream, odd_stream);
+	add_elements(tee, *even_stream, *odd_stream);
 	GstPad *p;
-	p = gst_element_get_static_pad(even_stream.internal_tee, "sink");
+	p = gst_element_get_static_pad(even_stream->internal_tee, "sink");
 	if(!p) {
 		throw std::runtime_error("Failed to get even stream sink pad");
 	}
 	gst_pad_add_probe(p, GST_PAD_PROBE_TYPE_BUFFER, frame_parity_probe_cb, &even_probe_data, nullptr);
 	g_object_unref(p);
-	p = gst_element_get_static_pad(odd_stream.internal_tee, "sink");
+	p = gst_element_get_static_pad(odd_stream->internal_tee, "sink");
 	if(!p) {
 		throw std::runtime_error("Failed to get odd stream sink pad");
 	}
 	gst_pad_add_probe(p, GST_PAD_PROBE_TYPE_BUFFER, frame_parity_probe_cb, &odd_probe_data, nullptr);
 }
 void Keela::SplitStreamBin::link() {
-	element_link_many(tee, even_stream);
-	element_link_many(tee, odd_stream);
-	link_queue(even_stream);
+	element_link_many(tee, *even_stream);
+	element_link_many(tee, *odd_stream);
+	link_queue(*even_stream);
 }
 
 GstPadProbeReturn Keela::SplitStreamBin::frame_parity_probe_cb(GstPad *pad, GstPadProbeInfo *info, gpointer user_data) {

--- a/keela-pipeline/splitstreambin.cpp
+++ b/keela-pipeline/splitstreambin.cpp
@@ -9,6 +9,18 @@ Keela::SplitStreamBin::SplitStreamBin() : even_stream("stream_even"), odd_stream
 }
 void Keela::SplitStreamBin::init() {
 	add_elements(tee, even_stream, odd_stream);
+	GstPad *p;
+	p = gst_element_get_static_pad(even_stream.internal_tee, "sink");
+	if(!p) {
+		throw std::runtime_error("Failed to get even stream sink pad");
+	}
+	gst_pad_add_probe(p, GST_PAD_PROBE_TYPE_BUFFER, frame_parity_probe_cb, &even_probe_data, nullptr);
+	g_object_unref(p);
+	p = gst_element_get_static_pad(odd_stream.internal_tee, "sink");
+	if(!p) {
+		throw std::runtime_error("Failed to get odd stream sink pad");
+	}
+	gst_pad_add_probe(p, GST_PAD_PROBE_TYPE_BUFFER, frame_parity_probe_cb, &odd_probe_data, nullptr);
 }
 void Keela::SplitStreamBin::link() {
 	element_link_many(tee, even_stream);

--- a/keela-pipeline/splitstreambin.cpp
+++ b/keela-pipeline/splitstreambin.cpp
@@ -1,0 +1,43 @@
+//
+// Created by brand on 12/26/2025.
+//
+
+#include "keela-pipeline/splitstreambin.h"
+
+#include "keela-pipeline/utils.h"
+Keela::SplitStreamBin::SplitStreamBin() : even_stream("stream_even"), odd_stream("stream_odd") {
+}
+void Keela::SplitStreamBin::init() {
+	add_elements(tee, even_stream, odd_stream);
+}
+void Keela::SplitStreamBin::link() {
+	element_link_many(tee, even_stream);
+	element_link_many(tee, odd_stream);
+	link_queue(even_stream);
+}
+
+GstPadProbeReturn Keela::SplitStreamBin::frame_parity_probe_cb(GstPad *pad, GstPadProbeInfo *info, gpointer user_data) {
+	GstBuffer *buffer = GST_PAD_PROBE_INFO_BUFFER(info);
+	FrameProbeData *probe_data = static_cast<FrameProbeData *>(user_data);
+	int parity = probe_data->parity;
+
+	int frame_number = 0;
+
+	// Some sources will have the frame number in the buffer offset (e.g.
+	// videotestsrc)
+	if(GST_BUFFER_OFFSET(buffer) != GST_BUFFER_OFFSET_NONE) {
+		frame_number = GST_BUFFER_OFFSET(buffer);
+	}
+	// But others like aravissrc do not set offset, so we fall back to our own
+	// per-camera counter
+	else {
+		// TODO: resolve narrowing conversion here
+		frame_number = (*probe_data->counter)++;
+	}
+
+	if(frame_number % 2 == parity) {
+		return GST_PAD_PROBE_OK;  // Pass the frame
+	} else {
+		return GST_PAD_PROBE_DROP;  // Drop the frame
+	}
+}

--- a/keela-test/CMakeLists.txt
+++ b/keela-test/CMakeLists.txt
@@ -9,7 +9,6 @@ FetchContent_Declare(
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 
-enable_testing()
 
 add_executable(keela-test main.cpp pipeline.cpp
         keela-exe.cpp

--- a/keela-test/main.cpp
+++ b/keela-test/main.cpp
@@ -7,7 +7,7 @@
 #include <spdlog/spdlog.h>
 
 int main(int argc, char **argv) {
-	spdlog::set_level(spdlog::level::trace);
+	spdlog::set_level(spdlog::level::debug);
 	testing::InitGoogleTest(&argc, argv);
 	gst_init(&argc, &argv);
 	return RUN_ALL_TESTS();

--- a/keela-test/pipeline.cpp
+++ b/keela-test/pipeline.cpp
@@ -8,6 +8,8 @@
 #include <keela-pipeline/transformbin.h>
 #include <spdlog/spdlog.h>
 
+#include "keela-pipeline/splitstreambin.h"
+
 TEST(KeelaPipeline, ConstructBin) {
 	auto bin = Keela::Bin();
 }
@@ -111,4 +113,8 @@ TEST(KeelaPipeline, CopyCaps) {
 	caps1.set_resolution(640, 480);
 	auto caps2 = Keela::Caps(static_cast<GstCaps *>(caps1));
 	ASSERT_TRUE(gst_caps_is_equal(caps1, caps2));
+}
+
+TEST(KeelaPipeline, SplitStreamBin) {
+	auto ssb = Keela::SplitStreamBin();
 }

--- a/keela-test/widgets.cpp
+++ b/keela-test/widgets.cpp
@@ -25,3 +25,12 @@ TEST(KeelaWidgets, CameraManagerStreamSplit) {
 	ASSERT_TRUE(cm.is_frame_splitting_enabled());
 	gst_element_set_state(cm, GST_STATE_NULL);
 }
+
+TEST(KeelaWidgets, CameraManagerGetStreams) {
+	auto cm = Keela::CameraManager(0, false);
+	gst_element_set_state(cm, GST_STATE_PLAYING);
+	ASSERT_EQ(cm.get_streams().size(), 1);
+	cm.set_frame_splitting(true);
+	ASSERT_EQ(cm.get_streams().size(), 2);
+	gst_element_set_state(cm, GST_STATE_NULL);
+}

--- a/keela-test/widgets.cpp
+++ b/keela-test/widgets.cpp
@@ -13,14 +13,15 @@ TEST(KeelaWidgets, ConstructGLCameraRender) {
     auto c = Keela::GLCameraRender(bin);
 }*/
 
-TEST(KeelaWidgets, ConstructCameraManagerGRAY8) {
+TEST(KeelaWidgets, ConstructCameraManager) {
 	auto cm = Keela::CameraManager(0, false);
 }
 
-TEST(KeelaWidgets, ConstructCameraManagerGRAY16LE) {
+TEST(KeelaWidgets, CameraManagerStreamSplit) {
 	auto cm = Keela::CameraManager(0, false);
-}
-
-TEST(KeelaWidgets, ConstructCameraManagerGRAY16BE) {
-	auto cm = Keela::CameraManager(0, false);
+	gst_element_set_state(cm, GST_STATE_PLAYING);
+	ASSERT_FALSE(cm.is_frame_splitting_enabled());
+	cm.set_frame_splitting(true);
+	ASSERT_TRUE(cm.is_frame_splitting_enabled());
+	gst_element_set_state(cm, GST_STATE_NULL);
 }

--- a/keela-widgets/cameramanager.cpp
+++ b/keela-widgets/cameramanager.cpp
@@ -193,6 +193,17 @@ void Keela::CameraManager::set_frame_splitting(bool split_enabled) {
 	add_elements(*stream);
 	element_link_many(transform, *stream);
 }
+std::vector<std::shared_ptr<Keela::CameraStreamBin>> Keela::CameraManager::get_streams() const {
+	std::vector<std::shared_ptr<Keela::CameraStreamBin>> streams;
+	if(!is_frame_splitting_enabled()) {
+		streams.push_back(std::dynamic_pointer_cast<Keela::CameraStreamBin>(stream));
+	} else {
+		auto split_stream = std::dynamic_pointer_cast<Keela::SplitStreamBin>(stream);
+		streams.push_back(split_stream->even_stream);
+		streams.push_back(split_stream->odd_stream);
+	}
+	return streams;
+}
 
 std::string Keela::CameraManager::get_filename(std::string directory, guint cam_id, std::string suffix) {
 	time_t timestamp = std::time(nullptr);

--- a/keela-widgets/cameramanager.cpp
+++ b/keela-widgets/cameramanager.cpp
@@ -5,6 +5,7 @@
 #include "keela-widgets/cameramanager.h"
 
 #include <arv.h>
+#include <keela-pipeline/splitstreambin.h>
 #include <keela-pipeline/utils.h>
 #include <spdlog/spdlog.h>
 
@@ -22,24 +23,20 @@ Keela::CameraManager::CameraManager(guint id, bool split_streams)
 		spdlog::info("Creating camera manager {}", id);
 		this->id = id;
 
-		Bin camera_stream_bin = static_cast<Bin &>(*camera_stream_even);
-
 		// Add all elements to the bin
 		// @todo: can we get rid of this caps_filter?
 		// I think we can just modify the source and the downstream elements will renegotiate
-		add_elements(camera, caps_filter, transform, tee_main, camera_stream_bin);
+		add_elements(camera, caps_filter, transform);
 
 		// Link main pipeline: camera -> capsfilter -> transform -> main_tee ->
 		// camera_stream_even
-		element_link_many(camera, caps_filter, transform, tee_main, camera_stream_bin);
-
-		if(split_streams) {
-			add_odd_camera_stream();
-		}
+		element_link_many(camera, caps_filter, transform);
 
 		// Set up camera control via aravissrc and AravisCamera
 		GstElement *camera_element = static_cast<GstElement *>(camera);
-		
+
+		set_frame_splitting(split_streams);
+
 		// Only initialize aravis_controller if the camera is an aravissrc
 		GstElementFactory *factory = gst_element_get_factory(camera_element);
 		const gchar *factory_name = gst_plugin_feature_get_name(factory);
@@ -47,13 +44,8 @@ Keela::CameraManager::CameraManager(guint id, bool split_streams)
 			aravis_controller = std::make_unique<AravisController>(camera_element);
 			spdlog::info("Initialized AravisController for camera {}", id);
 		} else {
-			spdlog::info("Camera {} is not an aravissrc ({}), skipping AravisController initialization", id, factory_name);
-		}
-
-		// Set up frame splitting if enabled
-		this->split_streams = split_streams;
-		if(split_streams) {
-			install_frame_splitting_probes();
+			spdlog::info("Camera {} is not an aravissrc ({}), skipping AravisController initialization", id,
+			             factory_name);
 		}
 
 		spdlog::info("Created camera manager {}", id);
@@ -179,91 +171,27 @@ void Keela::CameraManager::set_binning_factors(int binning_factor_x, int binning
 void Keela::CameraManager::start_recording() {
 	std::string suffix = split_streams ? "even" : "";
 
-	camera_stream_even->start_recording(get_filename(experiment_directory, this->id, suffix));
-
-	if(split_streams) {
-		camera_stream_odd->start_recording(get_filename(experiment_directory, this->id, "odd"));
-	}
+	throw std::runtime_error("Recording not yet implemented");
 }
 
 void Keela::CameraManager::stop_recording() {
-	camera_stream_even->stop_recording();
-
-	if(split_streams) {
-		camera_stream_odd->stop_recording();
-	}
+	throw std::runtime_error("Recording not yet implemented");
 }
 
-GstPadProbeReturn Keela::CameraManager::frame_parity_probe_cb(GstPad *pad, GstPadProbeInfo *info, gpointer user_data) {
-	GstBuffer *buffer = GST_PAD_PROBE_INFO_BUFFER(info);
-	FrameProbeData *probe_data = static_cast<FrameProbeData *>(user_data);
-	int parity = probe_data->parity;
+void Keela::CameraManager::set_frame_splitting(bool split_enabled) {
+	split_streams = split_enabled;
+	spdlog::info("Frame splitting {}", split_enabled ? "enabled" : "disabled");
 
-	int frame_number = 0;
-
-	// Some sources will have the frame number in the buffer offset (e.g.
-	// videotestsrc)
-	if(GST_BUFFER_OFFSET(buffer) != GST_BUFFER_OFFSET_NONE) {
-		frame_number = GST_BUFFER_OFFSET(buffer);
+	if(stream) {
+		stream->Eject(true);
 	}
-	// But others like aravissrc do not set offset, so we fall back to our own
-	// per-camera counter
-	else {
-		frame_number = (*probe_data->counter)++;
-	}
-
-	if(frame_number % 2 == parity) {
-		return GST_PAD_PROBE_OK;  // Pass the frame
+	if(split_enabled) {
+		stream = std::make_shared<Keela::SplitStreamBin>();
 	} else {
-		return GST_PAD_PROBE_DROP;  // Drop the frame
+		stream = std::make_shared<Keela::CameraStreamBin>("Single Camera Stream");
 	}
-}
-
-void Keela::CameraManager::set_frame_splitting(bool enabled) {
-	split_streams = enabled;
-	spdlog::info("Frame splitting {}", enabled ? "enabled" : "disabled");
-
-	if(enabled) {
-		if(camera_stream_odd == nullptr) {
-			// re-create the odd camera stream if it was previously ejected
-			camera_stream_odd = std::make_shared<CameraStreamBin>("camera_stream_odd");
-		}
-
-		// Install the probes now that the pipeline is set up
-		install_frame_splitting_probes();
-		add_odd_camera_stream();
-	} else {
-		// Remove probes so the even stream gets all frames
-		remove_frame_splitting_probes();
-
-		// Eject the odd CameraStreamBin
-		camera_stream_odd->PrepareEject();
-		camera_stream_odd->Eject(false);  // false = don't send EOS
-		camera_stream_odd = nullptr;      // clear the shared_ptr to allow re-creation later
-		spdlog::info("Ejected camera_stream_odd from pipeline");
-	}
-}
-
-void Keela::CameraManager::install_frame_splitting_probes() {
-	spdlog::info("Installing frame splitting probes");
-
-	// Install filtering probes on the sink pads of the even and odd tees
-	GstPad *even_sink_pad = gst_element_get_static_pad(camera_stream_even->internal_tee, "sink");
-	GstPad *odd_sink_pad = gst_element_get_static_pad(camera_stream_odd->internal_tee, "sink");
-
-	if(even_sink_pad) {
-		even_frame_probe_id = gst_pad_add_probe(even_sink_pad, GST_PAD_PROBE_TYPE_BUFFER, frame_parity_probe_cb,
-		                                        &even_probe_data, nullptr);
-		g_object_unref(even_sink_pad);
-		spdlog::info("Installed even frame filter probe");
-	}
-
-	if(odd_sink_pad) {
-		odd_frame_probe_id =
-		    gst_pad_add_probe(odd_sink_pad, GST_PAD_PROBE_TYPE_BUFFER, frame_parity_probe_cb, &odd_probe_data, nullptr);
-		g_object_unref(odd_sink_pad);
-		spdlog::info("Installed odd frame filter probe");
-	}
+	add_elements(*stream);
+	element_link_many(transform, *stream);
 }
 
 std::string Keela::CameraManager::get_filename(std::string directory, guint cam_id, std::string suffix) {
@@ -279,39 +207,6 @@ std::string Keela::CameraManager::get_filename(std::string directory, guint cam_
 	auto path = std::filesystem::path(directory) / (ss.str() + "cam_" + std::to_string(cam_id) + suffix + ".mkv");
 
 	return path.string();
-}
-
-void Keela::CameraManager::add_odd_camera_stream() {
-	Bin camera_stream_odd_bin = static_cast<Bin &>(*camera_stream_odd);
-
-	add_elements(camera_stream_odd_bin);
-
-	// Sync state with parent if the pipeline is already running
-	gboolean sync_result = gst_element_sync_state_with_parent(camera_stream_odd_bin);
-	if(!sync_result) {
-		spdlog::warn("Failed to sync camera_stream_odd state with parent");
-	}
-
-	// Link main tee to camera_stream_odd
-	element_link_many(tee_main, camera_stream_odd_bin);
-}
-
-void Keela::CameraManager::remove_probe_by_id(gulong &probe_id, GstPad *pad, const std::string &probe_name) {
-	gst_pad_remove_probe(pad, probe_id);
-	g_object_unref(pad);
-	probe_id = 0;
-	spdlog::info("Removed {} probe", probe_name);
-}
-
-void Keela::CameraManager::remove_frame_splitting_probes() {
-	if(even_frame_probe_id != 0) {
-		GstPad *even_sink_pad = gst_element_get_static_pad(camera_stream_even->internal_tee, "sink");
-		remove_probe_by_id(even_frame_probe_id, even_sink_pad, "even frame filter");
-	}
-	if(odd_frame_probe_id != 0) {
-		GstPad *odd_sink_pad = gst_element_get_static_pad(camera_stream_odd->internal_tee, "sink");
-		remove_probe_by_id(odd_frame_probe_id, odd_sink_pad, "odd frame filter");
-	}
 }
 
 void Keela::CameraManager::set_pipeline_state(GstState state) {

--- a/keela-widgets/cameramanager.cpp
+++ b/keela-widgets/cameramanager.cpp
@@ -26,12 +26,12 @@ Keela::CameraManager::CameraManager(guint id, bool split_streams)
 		// Add all elements to the bin
 		// @todo: can we get rid of this caps_filter?
 		// I think we can just modify the source and the downstream elements will renegotiate
-		add_elements(camera, caps_filter, transform);
+		add_elements(camera, caps_filter, transform, tee, snapshot);
 
 		// Link main pipeline: camera -> capsfilter -> transform -> main_tee ->
 		// camera_stream_even
-		element_link_many(camera, caps_filter, transform);
-
+		element_link_many(camera, caps_filter, transform, tee);
+		element_link_many(tee, snapshot);
 		// Set up camera control via aravissrc and AravisCamera
 		GstElement *camera_element = static_cast<GstElement *>(camera);
 
@@ -191,7 +191,7 @@ void Keela::CameraManager::set_frame_splitting(bool split_enabled) {
 		stream = std::make_shared<Keela::CameraStreamBin>("Single Camera Stream");
 	}
 	add_elements(*stream);
-	element_link_many(transform, *stream);
+	element_link_many(tee, *stream);
 }
 std::vector<std::shared_ptr<Keela::CameraStreamBin>> Keela::CameraManager::get_streams() const {
 	std::vector<std::shared_ptr<Keela::CameraStreamBin>> streams;

--- a/keela-widgets/cameramanager.cpp
+++ b/keela-widgets/cameramanager.cpp
@@ -192,6 +192,7 @@ void Keela::CameraManager::set_frame_splitting(bool split_enabled) {
 	}
 	add_elements(*stream);
 	element_link_many(tee, *stream);
+	set_pipeline_state(GST_STATE_PLAYING);
 }
 std::vector<std::shared_ptr<Keela::CameraStreamBin>> Keela::CameraManager::get_streams() const {
 	std::vector<std::shared_ptr<Keela::CameraStreamBin>> streams;

--- a/keela-widgets/keela-widgets/cameramanager.h
+++ b/keela-widgets/keela-widgets/cameramanager.h
@@ -146,10 +146,11 @@ class CameraManager final : public Keela::Bin {
 
 	SimpleElement caps_filter = SimpleElement("capsfilter");
 	SimpleElement tee = SimpleElement("tee");
-	SnapshotBin snapshot = SnapshotBin("snapshot");
 
    public:
 	TransformBin transform = TransformBin("transform");
+
+	SnapshotBin snapshot = SnapshotBin("snapshot");
 };
 }  // namespace Keela
 #endif  // CAMERAMANAGER_H

--- a/keela-widgets/keela-widgets/cameramanager.h
+++ b/keela-widgets/keela-widgets/cameramanager.h
@@ -12,6 +12,7 @@
 #include <keela-pipeline/recordbin.h>
 #include <keela-pipeline/simpleelement.h>
 #include <keela-pipeline/snapshotbin.h>
+#include <keela-pipeline/splitstreambin.h>
 #include <keela-pipeline/transformbin.h>
 #include <keela-widgets/AravisController.h>
 
@@ -95,64 +96,22 @@ class CameraManager final : public Keela::Bin {
 
 #pragma region Frame Splitting Stuff
 	// Control frame splitting
-	void set_frame_splitting(bool enabled);
+	void set_frame_splitting(bool split_enabled);
 
 	bool is_frame_splitting_enabled() const {
-		return split_streams;
+		auto maybe_split_stream = std::dynamic_pointer_cast<SplitStreamBin>(stream);
+		auto maybe_non_split_stream = std::dynamic_pointer_cast<CameraStreamBin>(stream);
+		return maybe_split_stream != nullptr && maybe_non_split_stream == nullptr;
+		// return split_streams;
 	}
-
-	// Camera Streams manage presentation, recording, and tracing of their
-	// respective frame streams
-	[[obsolete("obsoleted by SplitStreamBin")]]
-	std::shared_ptr<CameraStreamBin> camera_stream_even = std::make_shared<CameraStreamBin>("camera_stream_even");
-	[[obsolete("obsoleted by SplitStreamBin")]]
-	std::shared_ptr<CameraStreamBin> camera_stream_odd = std::make_shared<CameraStreamBin>("camera_stream_odd");
 
 	SimpleElement caps_filter = SimpleElement("capsfilter");
 	TransformBin transform = TransformBin("transform");
 
    private:
-	[[obsolete("obsoleted by SplitStreamBin")]]
-	gulong even_frame_probe_id = 0;
-	[[obsolete("obsoleted by SplitStreamBin")]]
-	gulong odd_frame_probe_id = 0;
+	// TODO: common interface for start/stop recording + ejectable
+	std::shared_ptr<Keela::EjectableElement> stream = nullptr;
 
-	// Per-camera frame counter for sources that don't set buffer offset
-	[[obsolete("obsoleted by SplitStreamBin")]]
-	guint64 manual_frame_counter = 0;
-
-	// Data structures for frame probes
-	[[obsolete("obsoleted by SplitStreamBin")]]
-	FrameProbeData even_probe_data{EVEN_FRAME, &manual_frame_counter};
-	[[obsolete("obsoleted by SplitStreamBin")]]
-	FrameProbeData odd_probe_data{ODD_FRAME, &manual_frame_counter};
-
-	//[[obsolete("obsoleted by SplitStreamBin")]]
-	// void set_up_frame_splitting();
-
-	[[obsolete("obsoleted by SplitStreamBin")]]
-	void install_frame_splitting_probes();
-
-	[[obsolete("obsoleted by SplitStreamBin")]]
-	void remove_frame_splitting_probes();
-
-	[[obsolete("obsoleted by SplitStreamBin")]]
-	void remove_probe_by_id(gulong &probe_id, GstPad *pad, const std::string &probe_name);
-
-	// Frame filtering callback
-	[[obsolete("obsoleted by SplitStreamBin")]]
-	static GstPadProbeReturn frame_parity_probe_cb(GstPad *pad, GstPadProbeInfo *info, gpointer user_data);
-
-	void add_odd_camera_stream();
-
-	/**
-	 * use to split a stream into as many identical streams as we want.
-	 *
-	 * NOTE: any elements that come after "tee" should probably inherit from
-	 * Keela::QueueBin
-	 */
-	[[obsolete("obsoleted by SplitStreamBin")]]
-	SimpleElement tee_main = SimpleElement("tee");
 #pragma endregion Frame Splitting Stuff
 	guint id;
 	bool split_streams;

--- a/keela-widgets/keela-widgets/cameramanager.h
+++ b/keela-widgets/keela-widgets/cameramanager.h
@@ -99,7 +99,9 @@ class CameraManager final : public Keela::Bin {
 
 	// Camera Streams manage presentation, recording, and tracing of their
 	// respective frame streams
+	[[obsolete("obsoleted by SplitStreamBin")]]
 	std::shared_ptr<CameraStreamBin> camera_stream_even = std::make_shared<CameraStreamBin>("camera_stream_even");
+	[[obsolete("obsoleted by SplitStreamBin")]]
 	std::shared_ptr<CameraStreamBin> camera_stream_odd = std::make_shared<CameraStreamBin>("camera_stream_odd");
 
 	SimpleElement camera;
@@ -107,25 +109,35 @@ class CameraManager final : public Keela::Bin {
 	TransformBin transform = TransformBin("transform");
 
    private:
+	[[obsolete("obsoleted by SplitStreamBin")]]
 	gulong even_frame_probe_id = 0;
+	[[obsolete("obsoleted by SplitStreamBin")]]
 	gulong odd_frame_probe_id = 0;
 
 	// Per-camera frame counter for sources that don't set buffer offset
+	[[obsolete("obsoleted by SplitStreamBin")]]
 	guint64 manual_frame_counter = 0;
 
 	// Data structures for frame probes
+	[[obsolete("obsoleted by SplitStreamBin")]]
 	FrameProbeData even_probe_data{EVEN_FRAME, &manual_frame_counter};
+	[[obsolete("obsoleted by SplitStreamBin")]]
 	FrameProbeData odd_probe_data{ODD_FRAME, &manual_frame_counter};
 
+	[[obsolete("obsoleted by SplitStreamBin")]]
 	void set_up_frame_splitting();
 
+	[[obsolete("obsoleted by SplitStreamBin")]]
 	void install_frame_splitting_probes();
 
+	[[obsolete("obsoleted by SplitStreamBin")]]
 	void remove_frame_splitting_probes();
 
+	[[obsolete("obsoleted by SplitStreamBin")]]
 	void remove_probe_by_id(gulong &probe_id, GstPad *pad, const std::string &probe_name);
 
 	// Frame filtering callback
+	[[obsolete("obsoleted by SplitStreamBin")]]
 	static GstPadProbeReturn frame_parity_probe_cb(GstPad *pad, GstPadProbeInfo *info, gpointer user_data);
 
 	guint id;
@@ -147,6 +159,7 @@ class CameraManager final : public Keela::Bin {
 	 * NOTE: any elements that come after "tee" should probably inherit from
 	 * Keela::QueueBin
 	 */
+	[[obsolete("obsoleted by SplitStreamBin")]]
 	SimpleElement tee_main = SimpleElement("tee");
 
 	/* at any moment there may be many active record bins

--- a/keela-widgets/keela-widgets/cameramanager.h
+++ b/keela-widgets/keela-widgets/cameramanager.h
@@ -99,12 +99,19 @@ class CameraManager final : public Keela::Bin {
 	void set_frame_splitting(bool split_enabled);
 
 	bool is_frame_splitting_enabled() const {
+		if(!stream) {
+			throw std::logic_error("stream is null");
+		}
 		auto maybe_split_stream = std::dynamic_pointer_cast<SplitStreamBin>(stream);
 		auto maybe_non_split_stream = std::dynamic_pointer_cast<CameraStreamBin>(stream);
+		if(!(maybe_non_split_stream != nullptr || maybe_split_stream != nullptr)) {
+			// this can only happen if stream is assigned to anything aside from CameraStreamBin or SplitStreamBin
+			throw std::logic_error("stream is an unknown subtype");
+		}
 		return maybe_split_stream != nullptr && maybe_non_split_stream == nullptr;
-		// return split_streams;
 	}
 
+	std::vector<std::shared_ptr<Keela::CameraStreamBin>> get_streams() const;
 	SimpleElement caps_filter = SimpleElement("capsfilter");
 	TransformBin transform = TransformBin("transform");
 

--- a/keela-widgets/keela-widgets/cameramanager.h
+++ b/keela-widgets/keela-widgets/cameramanager.h
@@ -23,11 +23,6 @@
 #define ODD_FRAME 1   // TODO: obsolete
 
 namespace Keela {
-// Structure to pass both parity and counter to frame probe callback
-struct FrameProbeData {
-	int parity;
-	guint64 *counter;
-};
 class CameraManager final : public Keela::Bin {
    public:
 	explicit CameraManager(guint id, bool split_streams);
@@ -112,8 +107,6 @@ class CameraManager final : public Keela::Bin {
 	}
 
 	std::vector<std::shared_ptr<Keela::CameraStreamBin>> get_streams() const;
-	SimpleElement caps_filter = SimpleElement("capsfilter");
-	TransformBin transform = TransformBin("transform");
 
    private:
 	// TODO: common interface for start/stop recording + ejectable
@@ -150,6 +143,13 @@ class CameraManager final : public Keela::Bin {
 	 * hardware capabilities and adjusting camera parameters.
 	 */
 	std::unique_ptr<AravisController> aravis_controller = nullptr;
+
+	SimpleElement caps_filter = SimpleElement("capsfilter");
+	SimpleElement tee = SimpleElement("tee");
+	SnapshotBin snapshot = SnapshotBin("snapshot");
+
+   public:
+	TransformBin transform = TransformBin("transform");
 };
 }  // namespace Keela
 #endif  // CAMERAMANAGER_H

--- a/keela-widgets/keela-widgets/cameramanager.h
+++ b/keela-widgets/keela-widgets/cameramanager.h
@@ -18,8 +18,8 @@
 #include <atomic>
 #include <set>
 
-#define EVEN_FRAME 0
-#define ODD_FRAME 1
+#define EVEN_FRAME 0  // TODO: obsolete
+#define ODD_FRAME 1   // TODO: obsolete
 
 namespace Keela {
 // Structure to pass both parity and counter to frame probe callback

--- a/keela-widgets/keela-widgets/cameramanager.h
+++ b/keela-widgets/keela-widgets/cameramanager.h
@@ -32,7 +32,7 @@ class CameraManager final : public Keela::Bin {
 	explicit CameraManager(guint id, bool split_streams);
 
 	~CameraManager() override;
-
+#pragma region Aravis Stuff
 	bool has_aravis_controller() const {
 		return aravis_controller != nullptr;
 	}
@@ -85,11 +85,15 @@ class CameraManager final : public Keela::Bin {
 
 	void set_binning_factors(int binning_factor_both);
 	void set_binning_factors(int binning_factor_x, int binning_factor_y);
+#pragma endregion Aravis Stuff
 
 	void start_recording();
 
 	void stop_recording();
 
+	SimpleElement camera;
+
+#pragma region Frame Splitting Stuff
 	// Control frame splitting
 	void set_frame_splitting(bool enabled);
 
@@ -104,7 +108,6 @@ class CameraManager final : public Keela::Bin {
 	[[obsolete("obsoleted by SplitStreamBin")]]
 	std::shared_ptr<CameraStreamBin> camera_stream_odd = std::make_shared<CameraStreamBin>("camera_stream_odd");
 
-	SimpleElement camera;
 	SimpleElement caps_filter = SimpleElement("capsfilter");
 	TransformBin transform = TransformBin("transform");
 
@@ -124,8 +127,8 @@ class CameraManager final : public Keela::Bin {
 	[[obsolete("obsoleted by SplitStreamBin")]]
 	FrameProbeData odd_probe_data{ODD_FRAME, &manual_frame_counter};
 
-	[[obsolete("obsoleted by SplitStreamBin")]]
-	void set_up_frame_splitting();
+	//[[obsolete("obsoleted by SplitStreamBin")]]
+	// void set_up_frame_splitting();
 
 	[[obsolete("obsoleted by SplitStreamBin")]]
 	void install_frame_splitting_probes();
@@ -140,18 +143,7 @@ class CameraManager final : public Keela::Bin {
 	[[obsolete("obsoleted by SplitStreamBin")]]
 	static GstPadProbeReturn frame_parity_probe_cb(GstPad *pad, GstPadProbeInfo *info, gpointer user_data);
 
-	guint id;
-	bool split_streams;
-
-	/// caps filter to apply to the entire stream
-	Caps base_caps;
-
-	/// caps filter determining the stream caps after scaling
-	Caps scaled_caps;
-
-	/// for now, experiment directory will be set to my temp directory until I
-	/// figure out gtk file dialogs
-	std::string experiment_directory = "C:\\temp";
+	void add_odd_camera_stream();
 
 	/**
 	 * use to split a stream into as many identical streams as we want.
@@ -161,13 +153,16 @@ class CameraManager final : public Keela::Bin {
 	 */
 	[[obsolete("obsoleted by SplitStreamBin")]]
 	SimpleElement tee_main = SimpleElement("tee");
+#pragma endregion Frame Splitting Stuff
+	guint id;
+	bool split_streams;
 
-	/* at any moment there may be many active record bins
-	 *
-	 * TODO: do these still need to be shared_ptr?
-	 *
-	 */
-	std::set<std::shared_ptr<RecordBin>> record_bins;
+	/// caps filter to apply to the entire stream
+	Caps base_caps;
+
+	/// for now, experiment directory will be set to my temp directory until I
+	/// figure out gtk file dialogs
+	std::string experiment_directory = "C:\\temp";
 
 	/*
 	 * prepends the filename with the current time to avoid overwriting files
@@ -176,8 +171,6 @@ class CameraManager final : public Keela::Bin {
 	 * enabled) supports cross-platform path joining
 	 */
 	static std::string get_filename(std::string directory, guint cam_id, std::string suffix = "");
-
-	void add_odd_camera_stream();
 
 	void set_pipeline_state(GstState state);
 


### PR DESCRIPTION
🚧 Under construction

This PR aims to extract the frame splitting logic in `CameraManager` into a class that may be interchangeably used in place of a singular `CameraStreamBin`

#48 Contains an interface `IRecordable` that should make the recording start/stop logic easier to handle when working with split/non-split pipelines