### PR TITLE
Add back-buffer to GLCameraRender

### DIFF
--- a/keela-widgets/GLCameraRender.cpp
+++ b/keela-widgets/GLCameraRender.cpp
@@ -90,8 +90,10 @@ void Keela::GLCameraRender::new_tex_sample(GstSample *sample) {
 			glPixelStorei(GL_UNPACK_SWAP_BYTES, GL_FALSE);
 		}
 
-		glBindTexture(GL_TEXTURE_2D, texture);
+
+		glBindTexture(GL_TEXTURE_2D, texture[0]);
 		glTexImage2D(GL_TEXTURE_2D, 0, GL_RED, width, height, 0, GL_RED, tex_fmt, mapInfo.data);
+		std::swap(texture[0], texture[1]);
 
 		gst_buffer_unmap(buf, &mapInfo);
 	} else {
@@ -171,8 +173,12 @@ void Keela::GLCameraRender::on_realize() {
 	glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(float), (void *)(2 * sizeof(float)));
 	glEnableVertexAttribArray(1);
 
-	glGenTextures(1, &texture);
-	glBindTexture(GL_TEXTURE_2D, texture);
+	glGenTextures(2, texture);
+	glBindTexture(GL_TEXTURE_2D, texture[0]);
+	// set nearest neighbors interpolation
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+	glBindTexture(GL_TEXTURE_2D, texture[1]);
 	// set nearest neighbors interpolation
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
@@ -192,7 +198,7 @@ bool Keela::GLCameraRender::on_render(const Glib::RefPtr<Gdk::GLContext> &contex
 
 	glUseProgram(shaderProgram);
 	glActiveTexture(GL_TEXTURE0);
-	glBindTexture(GL_TEXTURE_2D, texture);
+	glBindTexture(GL_TEXTURE_2D, texture[0]);
 
 	glUniform1i(glGetUniformLocation(shaderProgram, "videoTexture"), 0);
 	glUniform1i(glGetUniformLocation(shaderProgram, "heatmap_enabled"), m_controller.is_heatmap_enabled());

--- a/keela-widgets/keela-widgets/GLCameraRender.h
+++ b/keela-widgets/keela-widgets/GLCameraRender.h
@@ -72,7 +72,7 @@ class GLCameraRender final : public Gtk::GLArea {
 	unsigned int fragmentShader;
 	unsigned int shaderProgram;
 	unsigned int VAO;
-	unsigned int texture;
+	unsigned int texture[2];
 	std::shared_ptr<PresentationBin> bin;
 	float vertices[24] = {-1, -1, 0, 1, 1, 1, 1, 0, -1, 1, 0, 0, 1, -1, 1, 1, 1, 1, 1, 0, -1, -1, 0, 1};
 


### PR DESCRIPTION
This change introduces a second texture buffer for camera render data.

When data is being uploaded to an openGL texture, any draw calls that use that texture must stall until the upload is complete.

By introducing a second texture buffer, one buffer can be used for uploads while the other can be used for draw calls. This should prevent the stuttering behavior when recording at higher bit depths but will introduce an extra frame's worth of tail latency to every frame.

